### PR TITLE
Add 1Password authentication status message to wrapper

### DIFF
--- a/bin/claude-with-identity
+++ b/bin/claude-with-identity
@@ -182,6 +182,8 @@ if command -v op &>/dev/null; then
   OP_VERSION="$(op --version 2>/dev/null)" || OP_VERSION="unknown"
   debug_log "1Password CLI detected (version: ${OP_VERSION})"
 
+  echo "[Claude wrapper] Checking 1Password authentication..." >&2
+
   # Check for active session
   if ! op account get &>/dev/null; then
     debug_log "No active 1Password session, attempting signin..."


### PR DESCRIPTION
## Summary

- Adds user-facing message before 1Password authentication check in wrapper script
- Message: `[Claude wrapper] Checking 1Password authentication...`
- Appears before `op account get` session check (which triggers authentication in 1Password CLI v2)

## Problem Solved

Previously, users would run `claude` and immediately see the 1Password TouchID prompt with no indication that the wrapper was initiating authentication. This created confusion about the connection between running the wrapper and seeing the authentication dialog.

## Solution

Added message on line 185 of `bin/claude-with-identity` before the session check that can trigger authentication.

## User Experience

**No active session:**
```
$ claude
[Claude wrapper] Checking 1Password authentication...
# TouchID prompt appears
# Claude CLI launches
```

**Active session exists:**
```
$ claude
[Claude wrapper] Checking 1Password authentication...
# Claude CLI launches immediately (no TouchID)
```

**No op CLI installed:**
```
$ claude
# Claude CLI launches (no message)
```

## Testing

Tested with:
- ✅ No active session (shows message + TouchID prompt)
- ✅ Active session (shows message only, no prompt)
- ✅ Debug mode works correctly

## Review

- ✅ code-reviewer: PASS
- ✅ adversarial-reviewer: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)