### PR TITLE
Fix: Restore authentication message before session check

### DIFF
--- a/bin/claude-with-identity
+++ b/bin/claude-with-identity
@@ -182,9 +182,10 @@ if command -v op &>/dev/null; then
   OP_VERSION="$(op --version 2>/dev/null)" || OP_VERSION="unknown"
   debug_log "1Password CLI detected (version: ${OP_VERSION})"
 
+  echo "[Claude wrapper] Checking 1Password authentication..." >&2
+
   # Check for active session and attempt signin if needed
   if ! op account get &>/dev/null; then
-    echo "[Claude wrapper] Authenticating with 1Password..." >&2
     debug_log "No active 1Password session, attempting signin..."
 
     # Attempt signin (may succeed silently via app integration)


### PR DESCRIPTION
## Summary

Fixes regression introduced in PR #5 where the refactoring accidentally moved the wrapper authentication message inside a conditional, undoing the fix from PR #4.

## Problem

PR #5's refactoring moved the message from before the session check to inside the conditional:

**Before refactoring (PR #4 - correct):**
```bash
echo "[Claude wrapper] Checking 1Password authentication..." >&2

# Check for active session
if ! op account get &>/dev/null; then
```

**After refactoring (PR #5 - regression):**
```bash
# Check for active session and attempt signin if needed
if ! op account get &>/dev/null; then
  echo "[Claude wrapper] Authenticating with 1Password..." >&2
```

**Why this broke:**
- `op account get` itself triggers the authentication dialog (1Password CLI v2 behavior)
- User authenticates → check succeeds → message never displays
- Same problem we fixed in PR #4!

## Solution

Move message back to before the first session check:

```bash
echo "[Claude wrapper] Checking 1Password authentication..." >&2

# Check for active session and attempt signin if needed
if ! op account get &>/dev/null; then
  debug_log "No active 1Password session, attempting signin..."
```

## Testing

With this fix:
```
$ claude
[Claude wrapper] Checking 1Password authentication...
# TouchID prompt appears
# Claude launches
```

Without this fix (current regression):
```
$ claude
# TouchID prompt appears immediately (no message)
# Claude launches
```

## Related PRs

- PR #4: Original fix adding the message
- PR #5: Refactoring that accidentally undid PR #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)