### PR TITLE
fix(wrapper): preserve TTY stdin when loading 1Password secrets

### DIFF
--- a/bin/claude-with-identity
+++ b/bin/claude-with-identity
@@ -402,13 +402,8 @@ if [[ "${OP_ENABLED}" == "true" ]]; then
       exit 1
     fi
 
-    # Verify op inject produced non-empty output
-    if [[ ! -s "${resolved_file}" ]]; then
-      log_error "op inject produced empty file for ${secrets_file}"
-      exit 1
-    fi
-
     # Validate resolved file contains only safe variable assignments
+    # Note: Empty files (from comment-only secrets files) are valid and handled by validation
     # Allows quoted values but blocks command execution metacharacters
     # Pattern matches: KEY=value, KEY="value", KEY='value', comments, blank lines
     # Blocks: semicolons, backticks, $(), pipes, redirects outside quotes


### PR DESCRIPTION
## Summary
- Fixes the "Error: Input must be provided either through stdin or as a prompt argument when using --print" error
- Replaced `op run` with manual secret loading using `op inject` to preserve stdin as a TTY
- Added security hardening for environment variable handling

## Problem
When launching Claude in repositories with `.claude/secrets.op` files, the wrapper used `op run` to inject 1Password secrets. However, `op run` breaks the TTY connection, causing Claude Code to incorrectly assume `--print` mode instead of interactive mode.

## Solution
Replace `op run` with:
1. Read secrets files line-by-line
2. Parse key=value pairs using parameter expansion
3. Use `op inject` to resolve 1Password references
4. Export variables directly before exec'ing Claude
5. Preserve stdin as a TTY throughout

## Security Hardening
- Validate environment variable names (must match `^[A-Z_][A-Z0-9_]*$`)
- Use parameter expansion to handle values containing `=` characters
- Skip empty values to avoid overwriting existing environment variables
- Verify files are readable before processing
- Use `printf` instead of `echo` to preserve exact value content
- Avoid logging raw secret references in debug output

## Test plan
- [x] Tested in kebab-tax repo with `.claude/secrets.op` file
- [x] Verified secrets are correctly injected
- [x] Confirmed Claude launches in interactive mode (not --print mode)
- [x] Shellcheck clean
- [x] code-reviewer passed
- [x] adversarial-reviewer passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)