### PR TITLE
fix(wrapper): strip comments before passing to op inject

### DIFF
--- a/bin/claude-with-identity
+++ b/bin/claude-with-identity
@@ -390,14 +390,18 @@ if [[ "${OP_ENABLED}" == "true" ]]; then
       exit 1
     fi
 
+    # Strip comments before passing to op inject
+    # This prevents op inject from trying to resolve op:// patterns in comments
+    # grep -v returns exit 1 when no matches (no comments), which is fine
+    stripped_file="${temp_dir}/stripped-$(basename "${secrets_file}")"
+    grep -v '^[[:space:]]*#' "${secrets_file}" >"${stripped_file}" || true
+
     # Create temp file for resolved secrets
-    resolved_file="${temp_dir}/resolved-$(basename "${secrets_file}")" || {
-      log_error "Failed to create temp file for secret resolution"
-      exit 1
-    }
+    resolved_file="${temp_dir}/resolved-$(basename "${secrets_file}")"
 
     # Inject 1Password references - fails if any reference cannot be resolved
-    if ! op inject --in-file="${secrets_file}" --out-file="${resolved_file}" 2>&1; then
+    # Use stripped file to avoid resolving op:// patterns in comments
+    if ! op inject --in-file="${stripped_file}" --out-file="${resolved_file}" 2>&1; then
       log_error "Failed to inject secrets from ${secrets_file}"
       exit 1
     fi


### PR DESCRIPTION
## Summary
- Fixes issue where documentation comments in secrets files cause `op inject` to fail
- Strips comment lines before passing to `op inject`
- Handles files with no comments gracefully

## Problem
Documentation comments containing example `op://` patterns would cause `op inject` to fail:
```
# Reference format: op://vault-name/item-name/field-name
ACTUAL_SECRET=op://Personal/myitem/field
```

Error: `"vault-name" isn't a vault in this account`

## Solution
- Use `grep -v` to strip comment lines (lines starting with `#`)
- Create stripped temp file before calling `op inject`
- Pass stripped file to `op inject` instead of original
- Handle edge case where file has no comments (`grep -v` returns exit 1)

## Test plan
- [x] Tested with secrets file containing documentation comments
- [x] Tested with secrets file with no comments
- [x] Verified comments are stripped before `op inject` processing
- [x] code-reviewer: PASS
- [x] adversarial-reviewer: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)