### PR TITLE
fix(wrapper): normalize unquoted values from op inject

### DIFF
--- a/bin/claude-with-identity
+++ b/bin/claude-with-identity
@@ -141,6 +141,42 @@ else
   debug_log "GitHub token file not found: ${CLAUDE_GH_TOKEN_FILE}"
 fi
 
+# Normalize env file by quoting unquoted values
+# This ensures values with special characters (like \n in private keys) pass safety checks
+# and source correctly. Uses single quotes to preserve literal values.
+normalize_env_file() {
+  local input_file="$1"
+  local output_file="$2"
+  local line key value
+
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    # Skip blank lines and comments
+    if [[ -z "${line}" ]] || [[ "${line}" =~ ^[[:space:]]*# ]]; then
+      echo "${line}"
+      continue
+    fi
+
+    # Match KEY=value pattern
+    if [[ "${line}" =~ ^([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]]; then
+      key="${BASH_REMATCH[1]}"
+      value="${BASH_REMATCH[2]}"
+
+      # If already quoted (starts and ends with matching quotes), pass through
+      if [[ "${value}" =~ ^\".*\"$ ]] || [[ "${value}" =~ ^\'.*\'$ ]]; then
+        echo "${line}"
+      else
+        # Wrap in single quotes, escaping any internal single quotes
+        # Replace ' with '\'' (end quote, escaped literal quote, start quote)
+        value="${value//\'/\'\\\'\'}"
+        echo "${key}='${value}'"
+      fi
+    else
+      # Non-assignment lines pass through unchanged
+      echo "${line}"
+    fi
+  done <"${input_file}" >"${output_file}"
+}
+
 # Validate secrets file with path canonicalization
 validate_secrets_file() {
   local file="$1"
@@ -405,6 +441,12 @@ if [[ "${OP_ENABLED}" == "true" ]]; then
       log_error "Failed to inject secrets from ${secrets_file}"
       exit 1
     fi
+
+    # Normalize resolved file: quote unquoted values to handle special characters
+    # This ensures values like private keys with \n sequences pass safety checks
+    normalized_file="${temp_dir}/normalized-$(basename "${secrets_file}")"
+    normalize_env_file "${resolved_file}" "${normalized_file}"
+    mv "${normalized_file}" "${resolved_file}"
 
     # Validate resolved file contains only safe variable assignments
     # Note: Empty files (from comment-only secrets files) are valid and handled by validation

--- a/bin/claude-with-identity
+++ b/bin/claude-with-identity
@@ -451,9 +451,10 @@ if [[ "${OP_ENABLED}" == "true" ]]; then
     # Validate resolved file contains only safe variable assignments
     # Note: Empty files (from comment-only secrets files) are valid and handled by validation
     # Allows quoted values but blocks command execution metacharacters
-    # Pattern matches: KEY=value, KEY="value", KEY='value', comments, blank lines
+    # Pattern matches: KEY=value, KEY="value", KEY='value' (with '\'' escapes), comments, blank lines
     # Blocks: semicolons, backticks, $(), pipes, redirects outside quotes
-    safe_pattern="^([A-Za-z_][A-Za-z0-9_]*=(\"[^\"]*\"|'[^']*'|[^;\\\`\$()&<>|[:space:]]+)|#.*|[[:space:]]*)$"
+    # Single-quote pattern handles '\'' escape sequences (e.g., 'it'\''s working')
+    safe_pattern="^([A-Za-z_][A-Za-z0-9_]*=(\"[^\"]*\"|'[^']*'(\\\\''[^']*')*|[^;\\\`\$()&<>|[:space:]]+)|#.*|[[:space:]]*)$"
     if grep -vE "${safe_pattern}" "${resolved_file}" >/dev/null 2>&1; then
       log_error "Resolved secrets file contains unsafe content: ${secrets_file}"
       debug_log "Unsafe lines found:"


### PR DESCRIPTION
## Summary
- Fixes "unsafe content" error when loading 1Password secrets containing special characters (e.g., private keys with `\n` sequences)
- Adds `normalize_env_file()` function that wraps unquoted values in single quotes after `op inject` runs
- Single quotes preserve literal values without shell interpretation
- Internal single quotes are escaped using the `'\''` technique

## Problem
Values from 1Password like EC private keys contain literal `\n` sequences. When `op inject` outputs these unquoted:
```
PRIVATE_KEY=-----BEGIN EC PRIVATE KEY-----\nMHcCAQEE...
```

The safety regex correctly blocks backslashes in unquoted values (to prevent shell injection), causing the "unsafe content" error.

## Solution
Post-process `op inject` output to wrap unquoted values in single quotes:
```
PRIVATE_KEY='-----BEGIN EC PRIVATE KEY-----\nMHcCAQEE...'
```

This passes the safety check and preserves the literal value when sourced.

## Test plan
- [x] Verified normalization handles: simple values, values with `\n`, already-quoted values, values with single quotes, empty values, comments, blank lines
- [x] Verified safety check passes after normalization
- [x] Verified sourced values are correct (no extra quote characters)
- [x] Shellcheck passes
- [x] Code review passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)