### PR TITLE
feat: add project-specific pre-launch hook support

### DIFF
--- a/bin/claude-with-identity
+++ b/bin/claude-with-identity
@@ -487,12 +487,20 @@ if [[ "${OP_ENABLED}" == "true" ]]; then
         if [[ -x "${validated_hook}" ]] && check_file_permissions "${validated_hook}"; then
           debug_log "Running project pre-launch hook: ${validated_hook}"
           # shellcheck source=/dev/null
-          source "${validated_hook}"
+          if ! source "${validated_hook}"; then
+            log_error "Pre-launch hook failed: ${validated_hook}"
+            log_error "Fix the hook script or remove it to start Claude"
+            exit 1
+          fi
         else
-          log_warn "Skipping pre-launch hook - not executable or insecure permissions: ${validated_hook}"
+          log_error "Pre-launch hook has insecure permissions or is not executable: ${validated_hook}"
+          log_error "Fix permissions (chmod 700) or remove the hook to start Claude"
+          exit 1
         fi
       else
-        log_error "Pre-launch hook path escapes git repository, refusing to load"
+        log_error "Pre-launch hook path escapes git repository: ${validated_hook}"
+        log_error "Remove the symlink or use a hook file within the repository"
+        exit 1
       fi
     fi
   fi


### PR DESCRIPTION
## Summary

- Adds hook point for `.claude/pre-launch.sh` that runs after 1Password secrets are loaded but before Claude starts
- Enables projects to set up dynamic credentials that depend on resolved secrets
- Includes security validation (executable permission + ownership/permission checks)

## Motivation

MCP servers that require dynamic OAuth tokens need credentials available **before** Claude Code starts. The Plaid Dashboard MCP is a concrete example - it requires an OAuth token fetched using `PLAID_CLIENT_ID` and `PLAID_SECRET` from 1Password.

SessionStart hooks run too late because MCP servers initialize when Claude starts. This pre-launch hook runs at the right time.

## Example Usage

In a project's `.claude/pre-launch.sh`:

```bash
#!/usr/bin/env bash
# Fetch Plaid MCP OAuth token
if [[ -n "${PLAID_CLIENT_ID:-}" ]] && [[ -n "${PLAID_SECRET:-}" ]]; then
  PLAID_MCP_TOKEN=$("${GIT_ROOT}/.venv/bin/python" "${GIT_ROOT}/plaid_token.py" 2>/dev/null) || true
  [[ -n "${PLAID_MCP_TOKEN}" ]] && export PLAID_MCP_TOKEN
fi
```

## Security

- Requires executable permission (`-x`) on hook file
- Uses existing `check_file_permissions()` for ownership/permission validation
- Warns and skips if permissions are insecure

## Test plan

- [ ] Verify hook runs when `.claude/pre-launch.sh` exists and is executable
- [ ] Verify hook is skipped with warning when permissions are incorrect
- [ ] Verify hook is skipped silently when file doesn't exist
- [ ] Verify exported variables are available to Claude/MCP servers

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)