### PR TITLE
fix(wrapper): add warn_log alias for pre-launch script compatibility

### DIFF
--- a/bin/claude-with-identity
+++ b/bin/claude-with-identity
@@ -19,6 +19,11 @@ log_warn() {
   echo "WARNING: $*" >&2
 }
 
+# Alias for backward compatibility with pre-launch scripts
+warn_log() {
+  log_warn "$@"
+}
+
 # Git identity for Claude Code operations
 readonly CLAUDE_GIT_NAME="Claude Code Bot"
 readonly CLAUDE_GIT_EMAIL="claude-code@smartwatermelon.github"


### PR DESCRIPTION
## Summary

- Adds `warn_log()` as a backward compatibility alias for `log_warn()`
- Pre-launch scripts were calling `warn_log()` but the wrapper only defined `log_warn()`
- This caused "command not found" errors when warn code paths were triggered

## Context

Discovered while debugging a freeze issue in Claude Code. The function name mismatch was causing errors that disrupted terminal state when pre-launch scripts hit warning conditions.

## Test plan

- [x] Shellcheck passes
- [x] Pre-commit hooks pass
- [x] Code review clean

🤖 Generated with [Claude Code](https://claude.ai/code)