### PR TITLE
fix(wrapper): resolve symlinks before computing lib path

### DIFF
--- a/bin/claude-wrapper
+++ b/bin/claude-wrapper
@@ -4,10 +4,10 @@ set -euo pipefail
 # Claude Code wrapper - orchestrates modular components
 # Provides git identity, secrets management, and binary discovery
 
-# Determine library path relative to this script
-WRAPPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-WRAPPER_LIB="${WRAPPER_DIR}/../lib"
+# Determine library path relative to this script (resolve symlinks first)
 WRAPPER_PATH="$(realpath "${BASH_SOURCE[0]}")"
+WRAPPER_DIR="$(dirname "${WRAPPER_PATH}")"
+WRAPPER_LIB="${WRAPPER_DIR}/../lib"
 
 # Source all modules in dependency order
 # shellcheck source=../lib/logging.sh


### PR DESCRIPTION
## Summary

Fixes wrapper failing when invoked via symlink (e.g., `~/.local/bin/claude-wrapper`).

**Problem:** `BASH_SOURCE[0]` returns the symlink path, causing `WRAPPER_LIB` to resolve to `~/.local/lib/` instead of the actual `lib/` directory.

**Fix:** Use `realpath` to resolve symlinks before computing `WRAPPER_DIR`.

## Test plan

- [x] Tests pass
- [x] Verified via symlink: `CLAUDE_DEBUG=true ~/.local/bin/claude-wrapper --version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)