### PR TITLE
fix: isolate GitHub token selection by cwd git remote owner

### DIFF
--- a/bin/claude-wrapper
+++ b/bin/claude-wrapper
@@ -60,12 +60,17 @@ done < <(build_remote_control_args "$@" || true)
 
 # Launch claude with or without secrets injection
 if secrets_available; then
-  # Inject secrets into environment
+  # Inject secrets into environment (sets GH_TOKEN_* from 1Password)
   if ! inject_secrets; then
     log_error "Failed to inject secrets"
     exit 1
   fi
+fi
 
+# Load GitHub token AFTER secrets injection so 1Password env vars are available
+load_github_token
+
+if secrets_available; then
   # Run pre-launch hook if available
   GIT_ROOT="$(get_git_root)"
   if [[ -n "${GIT_ROOT}" ]]; then

--- a/lib/github-token.sh
+++ b/lib/github-token.sh
@@ -13,27 +13,84 @@ _gh_token_router_path() {
   printf '%s\n' "${this_dir}/gh-token-router.sh"
 }
 
-# Load GitHub CLI token with security checks and configure multi-org routing
-load_github_token() {
-  local token_loaded=false
+# Detect repo owner from cwd's git remote.
+# Outputs the lowercase owner name, or empty if not in a git repo / no GitHub remote.
+_detect_cwd_owner() {
+  local remote_url
+  if remote_url="$(git remote get-url origin 2>/dev/null)"; then
+    if [[ "${remote_url}" =~ github\.com[:/]([^/]+)/ ]]; then
+      printf '%s\n' "${BASH_REMATCH[1],,}"
+      return 0
+    fi
+  fi
+  return 1
+}
 
-  # Try default owner token first (CLAUDE_GH_DEFAULT_OWNER env var)
-  if [[ -n "${CLAUDE_GH_DEFAULT_OWNER:-}" ]]; then
-    local owner_file="${CLAUDE_GH_TOKEN_DIR_PATH}/gh-token.${CLAUDE_GH_DEFAULT_OWNER}"
-    if [[ -f "${owner_file}" ]]; then
-      if check_file_permissions "${owner_file}"; then
-        GH_TOKEN="$(<"${owner_file}")"
-        export GH_TOKEN
-        token_loaded=true
-        debug_log "GitHub token loaded from owner-specific file: ${owner_file}"
-      else
-        log_error "GitHub token file has insecure permissions: ${owner_file}"
-        return 1
-      fi
+# Try to load a token for a specific owner.
+# Checks GH_TOKEN_{OWNER} env var first (set by 1Password secrets injection),
+# then falls back to flat file gh-token.{owner}.
+# Returns 0 and exports GH_TOKEN on success, 1 on failure.
+_load_owner_token() {
+  local owner="$1"
+
+  # Check 1Password-injected env var
+  local normalized="${owner^^}"
+  normalized="${normalized//[.-]/_}"
+  local env_var_name="GH_TOKEN_${normalized}"
+  if [[ -n "${!env_var_name:-}" ]]; then
+    GH_TOKEN="${!env_var_name}"
+    export GH_TOKEN
+    debug_log "GitHub token loaded from env var: ${env_var_name}"
+    return 0
+  fi
+
+  # Fall back to flat file
+  local owner_file="${CLAUDE_GH_TOKEN_DIR_PATH}/gh-token.${owner}"
+  if [[ -f "${owner_file}" ]]; then
+    if check_file_permissions "${owner_file}"; then
+      GH_TOKEN="$(<"${owner_file}")"
+      export GH_TOKEN
+      debug_log "GitHub token loaded from file: ${owner_file}"
+      return 0
+    else
+      log_error "GitHub token file has insecure permissions: ${owner_file}"
+      return 1
     fi
   fi
 
-  # Fall back to default gh-token file
+  return 1
+}
+
+# Load GitHub CLI token with security checks and configure multi-org routing.
+# Token selection priority:
+#   1. CLAUDE_GH_DEFAULT_OWNER env var (explicit override)
+#   2. cwd git remote owner (auto-detect)
+#   3. Default gh-token file (legacy fallback)
+load_github_token() {
+  local token_loaded=false
+  local owner=""
+
+  # Priority 1: Explicit owner override
+  if [[ -n "${CLAUDE_GH_DEFAULT_OWNER:-}" ]]; then
+    owner="${CLAUDE_GH_DEFAULT_OWNER}"
+    debug_log "Using explicit default owner: ${owner}"
+  fi
+
+  # Priority 2: Detect from cwd git remote
+  if [[ -z "${owner}" ]]; then
+    if owner="$(_detect_cwd_owner)"; then
+      debug_log "Detected cwd owner from git remote: ${owner}"
+    else
+      owner=""
+    fi
+  fi
+
+  # Load owner-specific token
+  if [[ -n "${owner}" ]] && _load_owner_token "${owner}"; then
+    token_loaded=true
+  fi
+
+  # Priority 3: Legacy default file
   if [[ "${token_loaded}" != "true" ]] && [[ -f "${CLAUDE_GH_TOKEN_DEFAULT}" ]]; then
     if check_file_permissions "${CLAUDE_GH_TOKEN_DEFAULT}"; then
       GH_TOKEN="$(<"${CLAUDE_GH_TOKEN_DEFAULT}")"
@@ -69,5 +126,6 @@ load_github_token() {
   return 0
 }
 
-# Auto-load on source
-load_github_token
+# NOTE: Do not auto-load here. The wrapper calls load_github_token explicitly
+# after inject_secrets so that 1Password-injected GH_TOKEN_* env vars are
+# available for owner-based token selection.


### PR DESCRIPTION
## Summary
- `load_github_token()` now detects the repo owner from the cwd's git remote and selects the matching per-org token (`GH_TOKEN_{OWNER}` env var → flat file fallback)
- Moved `load_github_token` call to after `inject_secrets` in the wrapper so 1Password env vars are available
- Removed default `GH_TOKEN` from `secrets.op` and deleted the default `gh-token` flat file to prevent cross-org token leakage

Previously, sessions in nightowlstudiollc repos started with the smartwatermelon token as default, giving access to both orgs. Now the session token matches the cwd's repo owner.

## Test plan
- [ ] Start a session in `~/Developer/clients/amelia-boone` — verify only nightowlstudiollc repos accessible
- [ ] Start a session in `~/Developer/claude-wrapper` — verify only smartwatermelon repos accessible
- [ ] Start a session outside any git repo — verify no `GH_TOKEN` set (graceful degradation)
- [ ] Verify shellcheck passes on both modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)