### PR TITLE
feat: retry op read with exponential backoff for flaky wifi

### DIFF
--- a/lib/credentials.sh
+++ b/lib/credentials.sh
@@ -74,11 +74,21 @@ _load_gh_token() {
   fi
 
   local token
-  if command -v timeout &>/dev/null; then
-    token="$(timeout 5 op read "${_CREDS_GH_TOKEN_REF}" 2>/dev/null || true)"
-  else
-    token="$(op read "${_CREDS_GH_TOKEN_REF}" 2>/dev/null || true)"
-  fi
+  local -a backoff=(2 4 8)
+  local has_timeout=false
+  command -v timeout &>/dev/null && has_timeout=true
+
+  for wait_secs in "${backoff[@]}"; do
+    if "${has_timeout}"; then
+      token="$(timeout "${wait_secs}" op read "${_CREDS_GH_TOKEN_REF}" 2>/dev/null || true)"
+    else
+      token="$(op read "${_CREDS_GH_TOKEN_REF}" 2>/dev/null || true)"
+    fi
+    if [[ -n "${token}" ]]; then
+      break
+    fi
+    debug_log "op read attempt timed out after ${wait_secs}s, retrying…"
+  done
 
   if [[ -n "${token}" ]]; then
     export GH_TOKEN="${token}"

--- a/lib/credentials.sh
+++ b/lib/credentials.sh
@@ -76,6 +76,7 @@ _load_gh_token() {
   local token
   local -a backoff=(2 4 8)
   local has_timeout=false
+  local wait_secs
   command -v timeout &>/dev/null && has_timeout=true
 
   for wait_secs in "${backoff[@]}"; do
@@ -87,7 +88,7 @@ _load_gh_token() {
     if [[ -n "${token}" ]]; then
       break
     fi
-    debug_log "op read attempt timed out after ${wait_secs}s, retrying…"
+    debug_log "op read failed (timeout ${wait_secs}s)"
   done
 
   if [[ -n "${token}" ]]; then


### PR DESCRIPTION
## Summary
- Replaces single-timeout `op read` with retry loop using 2s/4s/8s exponential backoff
- Fast connections succeed on first attempt unchanged; flaky wifi gets 3 chances across ~14s
- Fixes intermittent `could not retrieve GH_TOKEN` warnings on slow networks

## Test plan
- [x] shellcheck passes
- [x] All 59 tests pass
- [x] Both code-reviewer and adversarial-reviewer PASS (2 commits)
- [ ] Manual: verify with `CLAUDE_DEBUG=true claude` on slow wifi — debug log should show retry attempts
- [ ] Manual: verify fast wifi still resolves on first attempt with no delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)