### PR TITLE
fix: guard empty RC_ARGS array to avoid bash 3.2 unbound-variable exit

### DIFF
--- a/bin/claude-wrapper
+++ b/bin/claude-wrapper
@@ -89,4 +89,8 @@ if secrets_available; then
 else
   debug_log "Executing: ${CLAUDE_BIN} [${#RC_ARGS[@]} rc args + ${#} args]"
 fi
-exec "${CLAUDE_BIN}" "${RC_ARGS[@]}" "$@"
+if [[ ${#RC_ARGS[@]} -gt 0 ]]; then
+  exec "${CLAUDE_BIN}" "${RC_ARGS[@]}" "$@"
+else
+  exec "${CLAUDE_BIN}" "$@"
+fi


### PR DESCRIPTION
## Summary
- `bin/claude-wrapper`'s `#!/usr/bin/env bash` shebang resolves to whichever `bash` is first on `PATH`. Any invocation where `PATH` puts `/bin` ahead of `/opt/homebrew/bin` (non-interactive launchd/cron contexts, minimal-PATH shells) runs under macOS's stock bash 3.2.57.
- Bash <4.4 throws `unbound variable` when expanding `"${array[@]}"` on a declared-but-empty array under `set -u` (fixed upstream in 4.4). Non-interactive invocations like `claude update` legitimately produce an empty `RC_ARGS` (no `--remote-control` flag needed), which crashed the wrapper at the final `exec` before it ever reached the real `claude` binary.
- Fix: only expand `RC_ARGS[@]]` when non-empty; otherwise `exec` without it. Behaviorally identical on any bash version, safe on 3.2.

Root-caused from a real failure last night: nightly `claude update` (via `com.andrewrich.updates` LaunchAgent, which explicitly runs under `/bin/bash -l`) failed with `RC_ARGS[@]: unbound variable`, triggered by a transient `brew shellenv` timeout that left `/bin` ahead of `/opt/homebrew/bin` on `PATH` for that run. The `brew shellenv` flakiness is being tracked separately in the dotfiles repo; this PR only addresses the wrapper's lack of bash-3.2 portability, which is worth fixing regardless of PATH ordering upstream.

## Test plan
- [x] `env -u CDPATH bash tests/test-wrapper.sh` — 59/59 pass
- [x] Reproduced the bash 3.2 bug directly and confirmed the fix resolves it:
  - `/bin/bash -c 'set -euo pipefail; a=(); echo "${a[@]}"'` → `unbound variable`
  - Same command against `/opt/homebrew/bin/bash` (5.3) → succeeds
- [x] `shellcheck --external-sources` clean on changed lines
- [x] Local pre-commit + pre-push reviews (code-reviewer, adversarial-reviewer, full-diff, codebase review) all PASS

https://claude.ai/code/session_013ZBWRNz2h1UKMRapc5Lkm9