### PR TITLE
fix(ci): SHA-pin fetch-metadata, fix spoofable actor check in dependabot-auto-merge.yml

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,8 +1,7 @@
 name: Dependabot Auto-Merge
 
 # Safely auto-merges Dependabot PRs after CI passes. Scope is narrow:
-#  - Only runs when github.actor == 'dependabot[bot]' (not spoofable;
-#    GitHub sets this from the authenticated user).
+#  - Only runs when github.event.pull_request.user.login == 'dependabot[bot]'
 #  - Patch/minor: always auto-merged.
 #  - Major: only auto-merged when EVERY listed dependency belongs to a
 #    trusted namespace (dependabot/, actions/, smartwatermelon/). One
@@ -24,7 +23,7 @@ name: Dependabot Auto-Merge
 # the trusted-namespace allowlist + version-comparison defense. See
 # docs/plans/2026-04-28-dependabot-auto-merge-c2.md.
 
-on:
+on: # zizmor: ignore[dangerous-triggers] intentional: dependabot-only via corrected actor check, minimal permissions, no PR code execution
   pull_request_target:
     types: [opened, synchronize, reopened]
 
@@ -34,12 +33,12 @@ permissions:
 
 jobs:
   auto-merge:
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
 
       - name: Decide if PR is auto-mergeable
         id: policy


### PR DESCRIPTION
Follow-up to the dev-env#21 no-op-approve-step remediation: zizmor's
pre-commit hook (which runs machine-globally, so it fires even in a
scratch clone) caught two pre-existing, real findings in this repo's
`dependabot-auto-merge.yml` while that PR was being prepared:

1. **`unpinned-uses`**: `dependabot/fetch-metadata@v3` was not SHA-pinned.
   Pinned to `25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3`, matching
   the pattern already used elsewhere in the fleet.
2. **`bot-conditions`**: `github.actor == 'dependabot[bot]'` is spoofable
   on `pull_request_target` (confirmed against zizmor's audit docs —
   `github.actor` is the last actor to touch the ref, not who opened the
   PR). Switched to `github.event.pull_request.user.login`, and corrected
   the header comment, which had incorrectly claimed `github.actor` was
   safe here.

The `pull_request_target` trigger itself (`dangerous-triggers`) is an
intentional, already-justified design (dependabot-only via the corrected
actor check, minimal permissions, no PR code execution) — suppressed
with a documented inline `# zizmor: ignore[dangerous-triggers]` comment
rather than changed.

Part of the fleet-wide remediation tracked in smartwatermelon/dev-env#21.
This PR is not merged automatically — merge requires separate explicit
authorization, same as any other PR.
