### PR TITLE
fix: credentials.sh hygiene — Linux guard, dedup timeout check

### DIFF
--- a/lib/credentials.sh
+++ b/lib/credentials.sh
@@ -18,6 +18,12 @@ readonly _CREDENTIALS_SH_LOADED=1
 readonly _CREDS_KEYCHAIN_SERVICE="op-service-account-claude-automation"
 readonly _CREDS_GH_TOKEN_REF="op://Automation/GitHub - CCCLI/Token"
 
+# Computed once so both credential-fetch functions below don't each re-run
+# `command -v timeout` on every invocation.
+_CREDS_HAS_TIMEOUT=false
+command -v timeout &>/dev/null && _CREDS_HAS_TIMEOUT=true
+readonly _CREDS_HAS_TIMEOUT
+
 # =========================================================
 # SERVICE ACCOUNT TOKEN
 # =========================================================
@@ -30,8 +36,13 @@ _load_service_account_token() {
     return 0
   fi
 
+  if ! command -v security &>/dev/null; then
+    debug_log "security command not available (non-macOS), skipping Keychain lookup"
+    return 0
+  fi
+
   local token
-  if command -v timeout &>/dev/null; then
+  if "${_CREDS_HAS_TIMEOUT}"; then
     token="$(timeout 3 security find-generic-password \
       -a "$(id -un)" \
       -s "${_CREDS_KEYCHAIN_SERVICE}" \
@@ -75,12 +86,10 @@ _load_gh_token() {
 
   local token
   local -a backoff=(2 4 8)
-  local has_timeout=false
   local wait_secs
-  command -v timeout &>/dev/null && has_timeout=true
 
   for wait_secs in "${backoff[@]}"; do
-    if "${has_timeout}"; then
+    if "${_CREDS_HAS_TIMEOUT}"; then
       token="$(timeout "${wait_secs}" op read "${_CREDS_GH_TOKEN_REF}" 2>/dev/null || true)"
     else
       token="$(op read "${_CREDS_GH_TOKEN_REF}" 2>/dev/null || true)"


### PR DESCRIPTION
## Summary

Three small, cosmetic/low-risk fixes to `lib/credentials.sh`, all confirmed still valid against current code:

- **Fixes #41**: Guards the `security find-generic-password` (macOS Keychain) call with `command -v security &>/dev/null`. On Linux/CI, this previously fell through to a misleading `log_warn` about a missing Keychain entry; now it emits a quiet `debug_log` and returns early.
- **Fixes #40**: Extracts the duplicated `command -v timeout &>/dev/null` check (previously run separately in both `_load_service_account_token` and `_load_gh_token`) into a single module-level `_CREDS_HAS_TIMEOUT` readonly flag, computed once, following the same pattern as the existing `_CREDS_GH_TOKEN_REF` readonly.

**Not fixed — #42** (chmod 644 `lib/credentials.sh`): investigated but not applied. Every other `lib/*.sh` file in this repo is mode 755, and the `shell-lint-fix` pre-commit hook actively enforces "executable if shebang present" — attempting the chmod fails the hook. Issue #42's stated premise ("shell libraries in this repo conventionally use 644") does not hold; the actual, enforced convention is 755. Recommend closing #42 as invalid.

## Test plan

- [x] `shellcheck --external-sources lib/credentials.sh` — clean
- [x] `bash tests/test-wrapper.sh` — 60/60 passed (includes credentials.sh ShellCheck compliance test)
- [x] `bash tests/test-remote-session.sh` — 26/26 passed
- [x] Verified `debug_log` only emits under `CLAUDE_DEBUG=true` (lib/logging.sh:9-13), confirming the new Linux guard stays silent by default
- [x] Local pre-commit/pre-push review agents (code-reviewer, adversarial-reviewer) both PASS

Filed https://github.com/smartwatermelon/claude-wrapper/issues/63 as a non-blocking follow-up: no test coverage exists yet for `credentials.sh`'s platform-conditional paths.

https://claude.ai/code/session_01RNSAmBxdVNsYY6PHB2VtCb