### PR TITLE
fix: skip GH_TOKEN retry loop when timeout is unavailable (#50, #51)

### DIFF
--- a/lib/credentials.sh
+++ b/lib/credentials.sh
@@ -88,17 +88,25 @@ _load_gh_token() {
   local -a backoff=(2 4 8)
   local wait_secs
 
-  for wait_secs in "${backoff[@]}"; do
-    if "${_CREDS_HAS_TIMEOUT}"; then
+  if "${_CREDS_HAS_TIMEOUT}"; then
+    for wait_secs in "${backoff[@]}"; do
       token="$(timeout "${wait_secs}" op read "${_CREDS_GH_TOKEN_REF}" 2>/dev/null || true)"
-    else
-      token="$(op read "${_CREDS_GH_TOKEN_REF}" 2>/dev/null || true)"
+      if [[ -n "${token}" ]]; then
+        break
+      fi
+      debug_log "op read failed (timeout ${wait_secs}s)"
+    done
+  else
+    # No timeout command available to bound each attempt, so retrying would
+    # only multiply the hang risk (an unbounded op read blocks forever on
+    # the first try, making retries unreachable) with no upside. Attempt
+    # exactly once instead of the usual backoff loop.
+    debug_log "timeout command unavailable, skipping retries (single attempt only)"
+    token="$(op read "${_CREDS_GH_TOKEN_REF}" 2>/dev/null || true)"
+    if [[ -z "${token}" ]]; then
+      debug_log "op read failed (no timeout available)"
     fi
-    if [[ -n "${token}" ]]; then
-      break
-    fi
-    debug_log "op read failed (timeout ${wait_secs}s)"
-  done
+  fi
 
   if [[ -n "${token}" ]]; then
     export GH_TOKEN="${token}"

--- a/tests/test-wrapper.sh
+++ b/tests/test-wrapper.sh
@@ -505,6 +505,47 @@ test_git_identity_behavior() {
   assert_contains "@" "${author_email}" "GIT_AUTHOR_EMAIL contains @ symbol"
 }
 
+test_credentials_no_timeout_behavior() {
+  echo ""
+  echo "Test 3.6: GH_TOKEN fetch skips retries when timeout is unavailable"
+
+  if [[ ! -f "${LIB_DIR}/credentials.sh" ]]; then
+    ((TESTS_RUN += 1))
+    ((TESTS_FAILED += 1))
+    echo -e "${RED}✗${NC} Cannot test - credentials.sh does not exist"
+    return 0
+  fi
+
+  # Build a stub PATH: a fake `op` that always fails (and records how many
+  # times it was invoked), and no `timeout` binary at all — this exercises
+  # the has_timeout=false branch of _load_gh_token (issues #50, #51).
+  local stub_dir call_log
+  stub_dir="$(mktemp -d)"
+  call_log="${stub_dir}/op-calls.log"
+  cat >"${stub_dir}/op" <<EOF
+#!/usr/bin/env bash
+echo "call" >>"${call_log}"
+exit 1
+EOF
+  chmod +x "${stub_dir}/op"
+
+  local debug_output
+  debug_output="$(
+    PATH="${stub_dir}:/usr/bin:/bin" \
+      OP_SERVICE_ACCOUNT_TOKEN="dummy-token-for-test" \
+      CLAUDE_DEBUG=true \
+      bash -c "unset GH_TOKEN; source '${LIB_DIR}/logging.sh'; source '${LIB_DIR}/credentials.sh'" 2>&1 1>/dev/null
+  )"
+
+  local call_count=0
+  [[ -f "${call_log}" ]] && call_count="$(wc -l <"${call_log}" | tr -d ' ')"
+
+  assert_equals "1" "${call_count}" "op read attempted exactly once (no retry loop without timeout)"
+  assert_contains "op read failed (no timeout available)" "${debug_output}" "Debug message reflects missing timeout, not a false timeout duration"
+
+  rm -rf "${stub_dir}"
+}
+
 # =============================================================================
 # SECTION 4: Integration Tests - Full wrapper behavior
 # =============================================================================
@@ -701,6 +742,7 @@ main() {
   test_permissions_autofix_behavior
   test_path_security_behavior
   test_git_identity_behavior
+  test_credentials_no_timeout_behavior
 
   # Section 4: Integration Tests
   echo ""

--- a/tests/test-wrapper.sh
+++ b/tests/test-wrapper.sh
@@ -517,8 +517,12 @@ test_credentials_no_timeout_behavior() {
   fi
 
   # Build a stub PATH: a fake `op` that always fails (and records how many
-  # times it was invoked), and no `timeout` binary at all — this exercises
-  # the has_timeout=false branch of _load_gh_token (issues #50, #51).
+  # times it was invoked), and NO `timeout` binary — this exercises the
+  # has_timeout=false branch of _load_gh_token (issues #50, #51). We must
+  # not rely on the real `timeout` being absent from system dirs (it's
+  # present at /usr/bin/timeout on Linux, unlike macOS), so the stub dir
+  # is used as the *entire* PATH and provides every binary credentials.sh
+  # and this test need — `command -v timeout` then genuinely finds nothing.
   local stub_dir call_log
   stub_dir="$(mktemp -d)"
   call_log="${stub_dir}/op-calls.log"
@@ -529,9 +533,21 @@ exit 1
 EOF
   chmod +x "${stub_dir}/op"
 
+  # Symlink in the real coreutils needed to actually run this: `env` and
+  # `bash` (the `op` stub's own #!/usr/bin/env bash shebang needs both),
+  # `id`/`cat` (credentials.sh/logging.sh), and `security` (macOS Keychain
+  # lookup, short-circuited here since OP_SERVICE_ACCOUNT_TOKEN is
+  # pre-set) — everything except `timeout`, which must be genuinely
+  # missing for this test to be valid.
+  local bin real_bin
+  for bin in env bash id security cat; do
+    real_bin="$(command -v "${bin}" 2>/dev/null || true)"
+    [[ -n "${real_bin}" ]] && ln -s "${real_bin}" "${stub_dir}/${bin}"
+  done
+
   local debug_output
   debug_output="$(
-    PATH="${stub_dir}:/usr/bin:/bin" \
+    PATH="${stub_dir}" \
       OP_SERVICE_ACCOUNT_TOKEN="dummy-token-for-test" \
       CLAUDE_DEBUG=true \
       bash -c "unset GH_TOKEN; source '${LIB_DIR}/logging.sh'; source '${LIB_DIR}/credentials.sh'" 2>&1 1>/dev/null


### PR DESCRIPTION
## Summary

Fixes two related bugs in `lib/credentials.sh`'s `_load_gh_token` retry logic:

- **Fixes #50** — Retries without `timeout` provide no benefit against hangs. When `timeout` is unavailable on the host (`has_timeout=false`), the previous code ran `op read` up to 3 times (backoff `2 4 8`) with no timeout bound on any attempt. Since an unbounded `op read` blocks forever on the *first* hang, retries 2 and 3 were unreachable — the loop only tripled exposure to the exact failure mode it exists to protect against, for zero benefit.
- **Fixes #51** — The failure debug message (`"op read failed (timeout ${wait_secs}s)"`) was always logged regardless of whether a timeout actually bounded the attempt, which is misleading on the no-timeout path.

## Design decision worth a human's attention

**This changes behavior on hosts without a `timeout` binary**: instead of 3 attempts with exponential backoff, `_load_gh_token` now makes exactly **one** attempt and gives up. This is an intentional tradeoff — retrying without a timeout guard is pure downside (same hang risk, no upside) — but it does mean a host without `timeout` no longer gets any retry-based resilience against transient (non-hanging) `op read` failures, e.g. a flaky-network blip that would have succeeded on retry 2. Given the retry feature exists specifically to survive flaky wifi, and `timeout`-less hosts can't safely retry at all, single-attempt-and-fail-fast seemed like the correct tradeoff, but flagging it explicitly since it is a real behavior change on that code path, not just a cosmetic fix.

The `has_timeout=true` path (the common case — `timeout` ships via coreutils/Homebrew on virtually every dev host) is unchanged: same 3-attempt backoff schedule, same per-attempt timeout bounds.

## Changes

- `lib/credentials.sh`: restructured `_load_gh_token`'s retry logic to branch on `has_timeout` *before* looping, rather than inside each iteration. When `has_timeout` is false, attempt `op read` once with a `debug_log` note explaining why retries were skipped. The failure debug message now accurately reflects whether a timeout bounded the attempt.
- `tests/test-wrapper.sh`: added `test_credentials_no_timeout_behavior`, which sources `credentials.sh` in a hermetic stub `PATH` (fake failing `op`, no `timeout` binary present) and asserts (a) `op` is invoked exactly once, and (b) the debug output says "no timeout available" rather than a false timeout duration.

## Test plan

- [x] `shellcheck --external-sources lib/credentials.sh` — clean
- [x] `shellcheck --external-sources tests/test-wrapper.sh` — clean (pre-existing SC2329 info-level finding on an unrelated unused helper, unchanged by this PR)
- [x] `bash tests/test-wrapper.sh` — 61/61 passing (added 2 new assertions)
- [x] `tests/test-gh-token-permissions.sh` not run — it's a live-environment integration test against real GitHub permission boundaries, unrelated to retry/timeout logic
- [x] Local pre-commit/pre-push review (code-reviewer + adversarial-reviewer + full-diff/codebase review) passed clean on both commits; codebase review filed two non-blocking follow-up issues (#60, resolved in a follow-up commit on this branch; #67, minor test-tmpdir cleanup hardening, left for later)

## Notes

This branch may land near `claude/fix-credentials-hygiene-*` (concurrent unrelated cosmetic fixes to the same file — chmod, a `command -v security` guard, dedup of `command -v timeout` into a module-level `_CREDS_HAS_TIMEOUT` flag). This PR was built from a clean clone off current `main` at the time of writing to avoid picking up that branch's uncommitted work; if it has since merged, a rebase may be needed before merge — the retry-loop logic here should apply cleanly on top since it only touches the body of `_load_gh_token`, not the `has_timeout` computation site.

https://claude.ai/code/session_01RNSAmBxdVNsYY6PHB2VtCb