### PR TITLE
test: add credentials.sh coverage, fix stub-dir leak

### DIFF
--- a/tests/test-credentials.sh
+++ b/tests/test-credentials.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Test suite for lib/credentials.sh
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${TEST_DIR}/.." && pwd)"
+LIB_DIR="${REPO_ROOT}/lib"
+
+# Every stub dir this suite creates nests under TEST_TMP, so the single
+# EXIT trap below sweeps all of them even if a test fails partway through
+# under set -euo pipefail — see issue #70.
+TEST_TMP="$(mktemp -d)"
+trap 'rm -rf "${TEST_TMP}"' EXIT
+
+# --- Helpers ---
+
+# Builds a stub bin dir containing only the named real binaries (symlinked),
+# so `command -v <bin>` genuinely fails for anything not listed. Called via
+# command substitution (a subshell), so it can't rely on a shared counter
+# variable to keep names unique — mktemp -d under TEST_TMP does that instead.
+make_stub_dir() {
+  local stub_dir
+  stub_dir="$(mktemp -d "${TEST_TMP}/stub.XXXXXX")"
+  local bin real_bin
+  for bin in "$@"; do
+    real_bin="$(command -v "${bin}" 2>/dev/null || true)"
+    [[ -n "${real_bin}" ]] && ln -s "${real_bin}" "${stub_dir}/${bin}"
+  done
+  echo "${stub_dir}"
+}
+
+assert_equals() {
+  local expected="$1" actual="$2" message="$3"
+  ((TESTS_RUN += 1))
+  if [[ "${expected}" == "${actual}" ]]; then
+    ((TESTS_PASSED += 1))
+    echo -e "${GREEN}✓${NC} ${message}"
+  else
+    ((TESTS_FAILED += 1))
+    echo -e "${RED}✗${NC} ${message}"
+    echo "  Expected: ${expected}"
+    echo "  Actual:   ${actual}"
+  fi
+  return 0
+}
+
+assert_contains() {
+  local needle="$1" haystack="$2" message="$3"
+  ((TESTS_RUN += 1))
+  if [[ "${haystack}" == *"${needle}"* ]]; then
+    ((TESTS_PASSED += 1))
+    echo -e "${GREEN}✓${NC} ${message}"
+  else
+    ((TESTS_FAILED += 1))
+    echo -e "${RED}✗${NC} ${message}"
+    echo "  Expected to contain: ${needle}"
+    echo "  Actual: ${haystack}"
+  fi
+  return 0
+}
+
+# --- Tests: _load_service_account_token ---
+
+echo ""
+echo "=== _load_service_account_token ==="
+
+# OP_SERVICE_ACCOUNT_TOKEN already set -> Keychain lookup skipped entirely.
+debug_output="$(
+  OP_SERVICE_ACCOUNT_TOKEN="preset-token" \
+    CLAUDE_DEBUG=true \
+    bash -c "source '${LIB_DIR}/logging.sh'; source '${LIB_DIR}/credentials.sh'" 2>&1 1>/dev/null
+)"
+assert_contains "already set, skipping Keychain lookup" "${debug_output}" \
+  "OP_SERVICE_ACCOUNT_TOKEN preset -> Keychain lookup skipped"
+
+# Non-macOS guard (issue #63): `security` unavailable -> quiet debug_log,
+# no misleading log_warn about the Keychain. This is the exact code path
+# introduced alongside the guard and previously had no test coverage.
+stub_dir="$(make_stub_dir env bash cat op)"
+debug_output="$(
+  PATH="${stub_dir}" \
+    CLAUDE_DEBUG=true \
+    bash -c "unset OP_SERVICE_ACCOUNT_TOKEN GH_TOKEN; source '${LIB_DIR}/logging.sh'; source '${LIB_DIR}/credentials.sh'" 2>&1 1>/dev/null
+)"
+assert_contains "security command not available (non-macOS), skipping Keychain lookup" "${debug_output}" \
+  "security unavailable -> debug_log notes non-macOS, lookup skipped"
+assert_equals "" "$(grep -i "not found in Keychain" <<<"${debug_output}" || true)" \
+  "security unavailable -> no misleading 'not found in Keychain' warning"
+
+# security present but the lookup fails (e.g. no matching Keychain entry) ->
+# warns, doesn't export OP_SERVICE_ACCOUNT_TOKEN.
+stub_dir="$(make_stub_dir env bash cat id timeout)"
+cat >"${stub_dir}/security" <<'EOF'
+#!/usr/bin/env bash
+exit 44
+EOF
+chmod +x "${stub_dir}/security"
+debug_output="$(
+  PATH="${stub_dir}" \
+    CLAUDE_DEBUG=true \
+    bash -c "unset OP_SERVICE_ACCOUNT_TOKEN GH_TOKEN; source '${LIB_DIR}/logging.sh'; source '${LIB_DIR}/credentials.sh'; echo \"RESULT=\${OP_SERVICE_ACCOUNT_TOKEN:-unset}\"" 2>&1
+)"
+assert_contains "RESULT=unset" "${debug_output}" \
+  "Keychain lookup fails -> OP_SERVICE_ACCOUNT_TOKEN stays unset"
+assert_contains "1Password service account token not found in Keychain" "${debug_output}" \
+  "Keychain lookup fails -> warns"
+
+# security present and succeeds -> token exported.
+stub_dir="$(make_stub_dir env bash cat id timeout)"
+cat >"${stub_dir}/security" <<'EOF'
+#!/usr/bin/env bash
+echo "found-token-value"
+EOF
+chmod +x "${stub_dir}/security"
+result="$(
+  PATH="${stub_dir}" \
+    bash -c "unset OP_SERVICE_ACCOUNT_TOKEN GH_TOKEN; source '${LIB_DIR}/logging.sh'; source '${LIB_DIR}/credentials.sh'; echo \"\${OP_SERVICE_ACCOUNT_TOKEN:-unset}\"" 2>/dev/null
+)"
+assert_equals "found-token-value" "${result}" \
+  "Keychain lookup succeeds -> OP_SERVICE_ACCOUNT_TOKEN exported"
+
+# --- Tests: _load_gh_token ---
+
+echo ""
+echo "=== _load_gh_token ==="
+
+# GH_TOKEN already set -> vault lookup skipped.
+debug_output="$(
+  GH_TOKEN="preset-gh-token" \
+    OP_SERVICE_ACCOUNT_TOKEN="dummy" \
+    CLAUDE_DEBUG=true \
+    bash -c "source '${LIB_DIR}/logging.sh'; source '${LIB_DIR}/credentials.sh'" 2>&1 1>/dev/null
+)"
+assert_contains "GH_TOKEN already set, skipping vault lookup" "${debug_output}" \
+  "GH_TOKEN preset -> vault lookup skipped"
+
+# OP_SERVICE_ACCOUNT_TOKEN unavailable -> GH_TOKEN fetch skipped (no op call).
+# `security` is deliberately omitted from the stub PATH so the Keychain
+# lookup can't populate OP_SERVICE_ACCOUNT_TOKEN from a real dev-machine
+# entry — this test needs it to genuinely stay unset.
+stub_dir="$(make_stub_dir env bash cat id timeout)"
+call_log="${stub_dir}/op-calls.log"
+cat >"${stub_dir}/op" <<EOF
+#!/usr/bin/env bash
+echo "call" >>"${call_log}"
+exit 1
+EOF
+chmod +x "${stub_dir}/op"
+debug_output="$(
+  PATH="${stub_dir}" \
+    CLAUDE_DEBUG=true \
+    bash -c "unset OP_SERVICE_ACCOUNT_TOKEN GH_TOKEN; source '${LIB_DIR}/logging.sh'; source '${LIB_DIR}/credentials.sh'" 2>&1 1>/dev/null
+)"
+assert_contains "Skipping GH_TOKEN fetch: OP_SERVICE_ACCOUNT_TOKEN not available" "${debug_output}" \
+  "No OP_SERVICE_ACCOUNT_TOKEN -> GH_TOKEN fetch skipped"
+assert_equals "" "$([[ -f "${call_log}" ]] && cat "${call_log}" || true)" \
+  "No OP_SERVICE_ACCOUNT_TOKEN -> op never invoked"
+
+# OP_SERVICE_ACCOUNT_TOKEN available, op read succeeds on first try (with
+# timeout available) -> GH_TOKEN exported, single call.
+stub_dir="$(make_stub_dir env bash cat id security timeout)"
+call_log="${stub_dir}/op-calls.log"
+cat >"${stub_dir}/op" <<EOF
+#!/usr/bin/env bash
+echo "call" >>"${call_log}"
+echo "vault-gh-token"
+EOF
+chmod +x "${stub_dir}/op"
+result="$(
+  PATH="${stub_dir}" \
+    OP_SERVICE_ACCOUNT_TOKEN="dummy" \
+    bash -c "unset GH_TOKEN; source '${LIB_DIR}/logging.sh'; source '${LIB_DIR}/credentials.sh'; echo \"\${GH_TOKEN:-unset}\"" 2>/dev/null
+)"
+assert_equals "vault-gh-token" "${result}" \
+  "op read succeeds -> GH_TOKEN exported from vault"
+assert_equals "1" "$(wc -l <"${call_log}" | tr -d ' ')" \
+  "op read succeeds on first attempt -> called exactly once"
+
+# --- Summary ---
+
+echo ""
+echo "Results: ${TESTS_PASSED}/${TESTS_RUN} passed, ${TESTS_FAILED} failed"
+if [[ "${TESTS_FAILED}" -gt 0 ]]; then
+  exit 1
+fi

--- a/tests/test-wrapper.sh
+++ b/tests/test-wrapper.sh
@@ -523,8 +523,13 @@ test_credentials_no_timeout_behavior() {
   # present at /usr/bin/timeout on Linux, unlike macOS), so the stub dir
   # is used as the *entire* PATH and provides every binary credentials.sh
   # and this test need — `command -v timeout` then genuinely finds nothing.
+  #
+  # Nested under TEST_TMP (not a standalone mktemp -d) so the script-level
+  # cleanup_test_env EXIT trap sweeps it even if this function fails
+  # partway through under set -euo pipefail — see issue #70.
   local stub_dir call_log
-  stub_dir="$(mktemp -d)"
+  stub_dir="${TEST_TMP}/credentials-no-timeout-stub"
+  mkdir -p "${stub_dir}"
   call_log="${stub_dir}/op-calls.log"
   cat >"${stub_dir}/op" <<EOF
 #!/usr/bin/env bash
@@ -558,8 +563,6 @@ EOF
 
   assert_equals "1" "${call_count}" "op read attempted exactly once (no retry loop without timeout)"
   assert_contains "op read failed (no timeout available)" "${debug_output}" "Debug message reflects missing timeout, not a false timeout duration"
-
-  rm -rf "${stub_dir}"
 }
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Adds `tests/test-credentials.sh` — dedicated coverage for `lib/credentials.sh`, which previously had only one narrow test (the no-timeout retry branch from #50/#51). The non-macOS `security` guard had zero coverage until this PR.
- Fixes the temp-dir leak in `test_credentials_no_timeout_behavior` (`tests/test-wrapper.sh`): it relied on reaching the end of the function to `rm -rf` its stub dir, which `set -euo pipefail` would skip on an early assertion failure. Both files now nest stub dirs under a `TEST_TMP` root swept by a single `EXIT` trap — the project's existing convention, no `shellcheck disable` directives.

Fixes #63, #70.

## Test plan
- [x] `bash tests/test-credentials.sh` — 11/11 pass
- [x] `bash tests/test-wrapper.sh` — 62/62 pass
- [x] `shellcheck --external-sources --severity=warning` clean on both files
- [x] Confirmed no leaked temp dirs after a run
- [x] Local pre-commit/pre-push review (code-reviewer + adversarial-reviewer, full-diff + codebase review) all pass

Claude-Session: https://claude.ai/code/session_01RNSAmBxdVNsYY6PHB2VtCb