### PR TITLE
fix(tests): add op-binary integrity guard, wire tests into CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,8 +19,12 @@ jobs:
       - name: Run test-credentials.sh
         run: bash tests/test-credentials.sh
 
-      - name: Run test-gh-token-permissions.sh
-        run: bash tests/test-gh-token-permissions.sh
+      # test-gh-token-permissions.sh is intentionally excluded: it's a
+      # human-in-the-loop integration test that must run from inside a live
+      # claude-wrapper session against a real sandbox repo with a live
+      # wrapper-issued GH_TOKEN. It guards on GIT_AUTHOR_NAME == "Claude
+      # Code Bot" and hard-exits on a vanilla runner, and it fires live
+      # mutating GitHub API requests unsuitable for unattended CI.
 
       - name: Run test-launch-dir-check.sh
         run: bash tests/test-launch-dir-check.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,4 +36,32 @@ jobs:
         run: bash tests/test-wrapper.sh
 
       - name: ShellCheck
+        run: |
+          shopt -s nullglob
+          lib_sh=(lib/*.sh)
+          bin_files=(bin/claude-wrapper)
+          test_sh=(tests/*.sh)
+          testlib_sh=(tests/lib/*.sh)
+
+          status=0
+          for label_count in \
+            "lib/*.sh:${#lib_sh[@]}" \
+            "bin/claude-wrapper:${#bin_files[@]}" \
+            "tests/*.sh:${#test_sh[@]}" \
+            "tests/lib/*.sh:${#testlib_sh[@]}"; do
+            label="${label_count%%:*}"
+            count="${label_count##*:}"
+            if [ "${count}" -eq 0 ]; then
+              echo "::error::ShellCheck pattern '${label}' matched no files - check test-suite layout" >&2
+              status=1
+            fi
+          done
+          if [ "${status}" -ne 0 ]; then
+            exit 1
+          fi
+
+          files=("${lib_sh[@]}" "${bin_files[@]}" "${test_sh[@]}" "${testlib_sh[@]}")
+          echo "ShellCheck target files:"
+          printf '  %s\n' "${files[@]}"
+          shellcheck --external-sources "${files[@]}"
         run: shellcheck --external-sources lib/*.sh bin/claude-wrapper tests/*.sh tests/lib/*.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,35 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  shell-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Run test-credentials.sh
+        run: bash tests/test-credentials.sh
+
+      - name: Run test-gh-token-permissions.sh
+        run: bash tests/test-gh-token-permissions.sh
+
+      - name: Run test-launch-dir-check.sh
+        run: bash tests/test-launch-dir-check.sh
+
+      - name: Run test-remote-session.sh
+        run: bash tests/test-remote-session.sh
+
+      - name: Run test-wrapper.sh
+        run: bash tests/test-wrapper.sh
+
+      - name: ShellCheck
+        run: shellcheck --external-sources lib/*.sh bin/claude-wrapper tests/*.sh tests/lib/*.sh

--- a/lib/permissions.sh
+++ b/lib/permissions.sh
@@ -3,13 +3,39 @@
 # Provides functions to check and fix file permissions
 # Requires: lib/logging.sh must be sourced first
 
+# Get file permission bits as octal string, robust across BSD/GNU stat.
+# GNU stat's `-f` flag means "filesystem status" (not "format string" as on
+# BSD/macOS), so probing with `stat -f ... || stat -c ...` is unreliable:
+# GNU stat -f prints multi-line filesystem info to stdout and can still
+# exit 0, so the fallback never triggers and garbage gets parsed as perms.
+# Explicit platform detection (one-shot `stat --version` probe) avoids that.
+_stat_perms() {
+  local file="$1"
+  if stat --version >/dev/null 2>&1; then
+    # GNU coreutils stat
+    stat -c '%a' "${file}" 2>/dev/null || echo "unknown"
+  else
+    # BSD/macOS stat
+    stat -f '%A' "${file}" 2>/dev/null || echo "unknown"
+  fi
+}
+
+_stat_owner_uid() {
+  local file="$1"
+  if stat --version >/dev/null 2>&1; then
+    stat -c '%u' "${file}" 2>/dev/null || echo "unknown"
+  else
+    stat -f '%u' "${file}" 2>/dev/null || echo "unknown"
+  fi
+}
+
 # Validate file permissions - BLOCKING (returns 1 if insecure)
 check_file_permissions() {
   local file="$1"
   local perms
 
   # Get permissions (Darwin vs Linux stat syntax)
-  perms="$(stat -f '%A' "${file}" 2>/dev/null || stat -c '%a' "${file}" 2>/dev/null || echo "unknown")"
+  perms="$(_stat_perms "${file}")"
 
   if [[ "${perms}" == "unknown" ]]; then
     log_error "Could not check permissions for ${file}"
@@ -31,7 +57,7 @@ check_file_permissions() {
   # Verify file is owned by current user
   local file_owner
   local current_uid
-  file_owner="$(stat -f '%u' "${file}" 2>/dev/null || stat -c '%u' "${file}" 2>/dev/null || echo "unknown")"
+  file_owner="$(_stat_owner_uid "${file}")"
   current_uid="$(id -u)" || current_uid="unknown"
   if [[ "${file_owner}" != "${current_uid}" ]]; then
     log_error "${file} is not owned by current user (owner: ${file_owner}, current: ${current_uid})"
@@ -51,7 +77,7 @@ ensure_secure_permissions() {
   local perms
 
   # Get permissions (Darwin vs Linux stat syntax)
-  perms="$(stat -f '%A' "${file}" 2>/dev/null || stat -c '%a' "${file}" 2>/dev/null || echo "unknown")"
+  perms="$(_stat_perms "${file}")"
 
   if [[ "${perms}" == "unknown" ]]; then
     log_error "Could not check permissions for ${file}"
@@ -61,7 +87,7 @@ ensure_secure_permissions() {
   # Verify file is owned by current user first
   local file_owner
   local current_uid
-  file_owner="$(stat -f '%u' "${file}" 2>/dev/null || stat -c '%u' "${file}" 2>/dev/null || echo "unknown")"
+  file_owner="$(_stat_owner_uid "${file}")"
   current_uid="$(id -u)" || current_uid="unknown"
   if [[ "${file_owner}" != "${current_uid}" ]]; then
     log_error "${file} is not owned by current user (owner: ${file_owner}, current: ${current_uid})"

--- a/tests/lib/op-guard.sh
+++ b/tests/lib/op-guard.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Guards against the failure mode in issue #79: a test that builds a stub
+# `op` binary somehow escapes its isolated PATH sandbox and overwrites the
+# real system `op` (1Password CLI) at its real location.
+#
+# Committed test logic already writes stubs only under mktemp'd stub dirs
+# and never resolves a write target via `command -v`, so this isn't closing
+# a known hole in current code — it's a tripwire for future regressions
+# (e.g. manual iteration on stub-writing code that slips a `PATH=` prefix or
+# swaps a read for a write). Source this file, then call
+# `op_guard_snapshot` once before any stub PATH tests run and
+# `op_guard_verify` once after — normally via an EXIT trap so it still runs
+# on early test failure.
+#
+# Usage:
+#   # shellcheck source=lib/op-guard.sh
+#   source "${TEST_DIR}/lib/op-guard.sh"
+#   op_guard_snapshot
+#   trap 'op_guard_verify; <other-cleanup>' EXIT
+#   ... tests ...
+
+_OP_GUARD_REAL_PATH=""
+_OP_GUARD_REAL_SIZE=""
+
+# Records the real `op` binary's resolved path and size before any stub-PATH
+# tests run. No-ops (with a stderr note) if `op` isn't installed at all —
+# e.g. on CI runners — since there's nothing to protect in that case.
+op_guard_snapshot() {
+  _OP_GUARD_REAL_PATH="$(command -v op 2>/dev/null || true)"
+  if [[ -z "${_OP_GUARD_REAL_PATH}" ]]; then
+    echo "op-guard: no system 'op' binary on PATH, skipping integrity check" >&2
+    return 0
+  fi
+  _OP_GUARD_REAL_SIZE="$(wc -c <"${_OP_GUARD_REAL_PATH}" 2>/dev/null | tr -d ' ')"
+}
+
+# Re-resolves `op` after the suite runs and fails loudly if the path that
+# was real before is now missing, resolves somewhere else, or shrank to
+# something stub-shaped (a hand-written shell stub is well under 1KB; the
+# real 1Password CLI binary is tens of MB).
+op_guard_verify() {
+  [[ -z "${_OP_GUARD_REAL_PATH}" ]] && return 0
+
+  if [[ ! -e "${_OP_GUARD_REAL_PATH}" ]]; then
+    echo "op-guard: FATAL - real op binary at ${_OP_GUARD_REAL_PATH} is gone after test run" >&2
+    exit 1
+  fi
+
+  local post_size
+  post_size="$(wc -c <"${_OP_GUARD_REAL_PATH}" 2>/dev/null | tr -d ' ')"
+
+  if [[ "${post_size}" != "${_OP_GUARD_REAL_SIZE}" ]]; then
+    echo "op-guard: FATAL - ${_OP_GUARD_REAL_PATH} changed size during test run (${_OP_GUARD_REAL_SIZE} -> ${post_size} bytes) - it may have been overwritten by a test stub (see issue #79)" >&2
+    exit 1
+  fi
+
+  # Belt-and-suspenders floor: even if size happened to match, a binary
+  # this small can't be a real 1Password CLI build.
+  if [[ "${post_size}" -lt 1000000 ]]; then
+    echo "op-guard: FATAL - ${_OP_GUARD_REAL_PATH} is only ${post_size} bytes, too small to be the real 1Password CLI (see issue #79)" >&2
+    exit 1
+  fi
+}

--- a/tests/lib/op-guard.sh
+++ b/tests/lib/op-guard.sh
@@ -31,6 +31,7 @@ op_guard_snapshot() {
     echo "op-guard: no system 'op' binary on PATH, skipping integrity check" >&2
     return 0
   fi
+  # shellcheck disable=SC2312  # wc's exit status is intentionally discarded here: a failed/empty read is caught downstream by the empty-string check on _OP_GUARD_REAL_SIZE, not by wc's own exit code.
   _OP_GUARD_REAL_SIZE="$(wc -c <"${_OP_GUARD_REAL_PATH}" 2>/dev/null | tr -d ' ')"
 }
 
@@ -47,6 +48,7 @@ op_guard_verify() {
   fi
 
   local post_size
+  # shellcheck disable=SC2312  # wc's exit status is intentionally discarded here: a failed/empty read is caught by the empty-string check below, not by wc's own exit code.
   post_size="$(wc -c <"${_OP_GUARD_REAL_PATH}" 2>/dev/null | tr -d ' ')"
 
   if [[ -z "${post_size}" ]]; then

--- a/tests/lib/op-guard.sh
+++ b/tests/lib/op-guard.sh
@@ -49,6 +49,11 @@ op_guard_verify() {
   local post_size
   post_size="$(wc -c <"${_OP_GUARD_REAL_PATH}" 2>/dev/null | tr -d ' ')"
 
+  if [[ -z "${post_size}" ]]; then
+    echo "op-guard: FATAL - ${_OP_GUARD_REAL_PATH} exists but became unreadable during test run (see issue #79)" >&2
+    exit 1
+  fi
+
   if [[ "${post_size}" != "${_OP_GUARD_REAL_SIZE}" ]]; then
     echo "op-guard: FATAL - ${_OP_GUARD_REAL_PATH} changed size during test run (${_OP_GUARD_REAL_SIZE} -> ${post_size} bytes) - it may have been overwritten by a test stub (see issue #79)" >&2
     exit 1

--- a/tests/lib/op-guard.sh
+++ b/tests/lib/op-guard.sh
@@ -31,8 +31,14 @@ op_guard_snapshot() {
     echo "op-guard: no system 'op' binary on PATH, skipping integrity check" >&2
     return 0
   fi
-  # shellcheck disable=SC2312  # wc's exit status is intentionally discarded here: a failed/empty read is caught downstream by the empty-string check on _OP_GUARD_REAL_SIZE, not by wc's own exit code.
+  # shellcheck disable=SC2312  # wc's exit status is intentionally discarded here: a failed/empty read is caught by the explicit empty-string check below, not by wc's own exit code.
   _OP_GUARD_REAL_SIZE="$(wc -c <"${_OP_GUARD_REAL_PATH}" 2>/dev/null | tr -d ' ')"
+
+  if [[ -z "${_OP_GUARD_REAL_SIZE}" ]]; then
+    echo "op-guard: could not read size of ${_OP_GUARD_REAL_PATH}, skipping integrity check" >&2
+    _OP_GUARD_REAL_PATH=""
+    return 0
+  fi
 }
 
 # Re-resolves `op` after the suite runs and fails loudly if the path that

--- a/tests/test-credentials.sh
+++ b/tests/test-credentials.sh
@@ -14,7 +14,7 @@ TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${TEST_DIR}/.." && pwd)"
 LIB_DIR="${REPO_ROOT}/lib"
 
-# shellcheck source=lib/op-guard.sh
+# shellcheck source=tests/lib/op-guard.sh
 source "${TEST_DIR}/lib/op-guard.sh"
 
 # Every stub dir this suite creates nests under TEST_TMP, so the single

--- a/tests/test-credentials.sh
+++ b/tests/test-credentials.sh
@@ -14,11 +14,16 @@ TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${TEST_DIR}/.." && pwd)"
 LIB_DIR="${REPO_ROOT}/lib"
 
+# shellcheck source=lib/op-guard.sh
+source "${TEST_DIR}/lib/op-guard.sh"
+
 # Every stub dir this suite creates nests under TEST_TMP, so the single
 # EXIT trap below sweeps all of them even if a test fails partway through
-# under set -euo pipefail — see issue #70.
+# under set -euo pipefail — see issue #70. op_guard_verify runs first so it
+# still catches a clobbered system `op` even on early failure (see #79).
 TEST_TMP="$(mktemp -d)"
-trap 'rm -rf "${TEST_TMP}"' EXIT
+trap 'op_guard_verify; rm -rf "${TEST_TMP}"' EXIT
+op_guard_snapshot
 
 # --- Helpers ---
 

--- a/tests/test-wrapper.sh
+++ b/tests/test-wrapper.sh
@@ -450,7 +450,7 @@ test_permissions_autofix_behavior() {
   bash -c "source '${LIB_DIR}/logging.sh'; source '${LIB_DIR}/permissions.sh'; ensure_secure_permissions '${test_file}' '400'" 2>/dev/null
 
   local perms
-  perms="$(stat -f '%A' "${test_file}" 2>/dev/null || stat -c '%a' "${test_file}" 2>/dev/null)"
+  perms="$(bash -c "source '${LIB_DIR}/permissions.sh'; _stat_perms '${test_file}'")"
   assert_equals "400" "${perms}" "ensure_secure_permissions fixes to target permissions"
 }
 

--- a/tests/test-wrapper.sh
+++ b/tests/test-wrapper.sh
@@ -20,6 +20,9 @@ REPO_ROOT="$(cd "${TEST_DIR}/.." && pwd)"
 WRAPPER="${REPO_ROOT}/bin/claude-wrapper"
 LIB_DIR="${REPO_ROOT}/lib"
 
+# shellcheck source=lib/op-guard.sh
+source "${TEST_DIR}/lib/op-guard.sh"
+
 # Temporary test environment
 TEST_TMP=""
 
@@ -32,6 +35,9 @@ setup_test_env() {
 }
 
 cleanup_test_env() {
+  # Runs first so it still catches a clobbered system `op` even if a test
+  # failed partway through under set -euo pipefail — see issue #79.
+  op_guard_verify
   if [[ -n "${TEST_TMP:-}" ]] && [[ -d "${TEST_TMP}" ]]; then
     rm -rf "${TEST_TMP}"
   fi
@@ -39,6 +45,7 @@ cleanup_test_env() {
 
 # Trap cleanup on exit
 trap cleanup_test_env EXIT
+op_guard_snapshot
 
 # Test helpers
 # Note: Using ((var += 1)) instead of ((var++)) per CLAUDE.md guidelines

--- a/tests/test-wrapper.sh
+++ b/tests/test-wrapper.sh
@@ -20,7 +20,7 @@ REPO_ROOT="$(cd "${TEST_DIR}/.." && pwd)"
 WRAPPER="${REPO_ROOT}/bin/claude-wrapper"
 LIB_DIR="${REPO_ROOT}/lib"
 
-# shellcheck source=lib/op-guard.sh
+# shellcheck source=tests/lib/op-guard.sh
 source "${TEST_DIR}/lib/op-guard.sh"
 
 # Temporary test environment


### PR DESCRIPTION
## Summary
- Fixes #79 (HIGH): adds a tripwire that fails loudly if the real system `op` (1Password CLI) binary is deleted, shrunk, or moved during a test run, and wires all applicable shell test suites into a new CI workflow so regressions are caught before merge, not just on a maintainer's machine.
- Committed test logic in `test-credentials.sh`/`test-wrapper.sh` was already correctly isolated (stubs only ever written under `mktemp`'d dirs), so this is defense-in-depth per the issue's own root-cause analysis, not a fix to a reproducible bug in the tests themselves.

## Changes
- `tests/lib/op-guard.sh` (new): `op_guard_snapshot`/`op_guard_verify` — records the real `op` binary's resolved path + size before stub-PATH tests run, verifies unchanged after (existence, readability, size match, 1MB size floor), fails with `exit 1` and a clear message referencing #79 if tripped. No-ops on CI where `op` isn't installed.
- `tests/test-credentials.sh`, `tests/test-wrapper.sh`: wired to call `op_guard_snapshot` at startup and `op_guard_verify` first in their EXIT/cleanup traps.
- `.github/workflows/tests.yml` (new): runs `test-credentials.sh`, `test-launch-dir-check.sh`, `test-remote-session.sh`, `test-wrapper.sh`, and `shellcheck --external-sources` on `ubuntu-latest` for every PR and push to `main`. Deliberately excludes `test-gh-token-permissions.sh` — that's a human-in-the-loop integration test that hard-exits outside a live wrapper session and fires live mutating GitHub API calls against a sandbox repo, unsuitable for headless CI (documented inline).

## Test plan
- [x] `bash tests/test-credentials.sh` — 11/11 passed
- [x] `bash tests/test-wrapper.sh` — 61/61 passed
- [x] `bash tests/test-launch-dir-check.sh` — 6/6 passed
- [x] `bash tests/test-remote-session.sh` — 25/26 passed (1 pre-existing failure unrelated to this change, confirmed present on clean `main` too — environmental, repo-name derivation depends on clone location)
- [x] Confirmed real `op` binary size unchanged (39974784 bytes) before/after full suite run
- [x] Sanity-tested `op_guard_verify` actually trips FATAL + exit 1 when a stub `op` is substituted
- [x] `shellcheck --external-sources` clean (only pre-existing info-level SC1091/SC2312 noise, same baseline as `main`)
- [x] `zizmor` clean on the new workflow
- [x] Local pre-commit/pre-push hooks (Semgrep, code-reviewer, adversarial-reviewer, full-diff + codebase review) all passed

https://claude.ai/code/session_019yrvtEbtQxBxDmZ4Fu9GrU