### PR TITLE
fix(permissions): use explicit platform detection instead of stat fallback chaining

### DIFF
--- a/lib/permissions.sh
+++ b/lib/permissions.sh
@@ -3,13 +3,39 @@
 # Provides functions to check and fix file permissions
 # Requires: lib/logging.sh must be sourced first
 
+# Get file permission bits as octal string, robust across BSD/GNU stat.
+# GNU stat's `-f` flag means "filesystem status" (not "format string" as on
+# BSD/macOS), so probing with `stat -f ... || stat -c ...` is unreliable:
+# GNU stat -f prints multi-line filesystem info to stdout and can still
+# exit 0, so the fallback never triggers and garbage gets parsed as perms.
+# Explicit platform detection (one-shot `stat --version` probe) avoids that.
+_stat_perms() {
+  local file="$1"
+  if stat --version >/dev/null 2>&1; then
+    # GNU coreutils stat
+    stat -c '%a' "${file}" 2>/dev/null || echo "unknown"
+  else
+    # BSD/macOS stat
+    stat -f '%A' "${file}" 2>/dev/null || echo "unknown"
+  fi
+}
+
+_stat_owner_uid() {
+  local file="$1"
+  if stat --version >/dev/null 2>&1; then
+    stat -c '%u' "${file}" 2>/dev/null || echo "unknown"
+  else
+    stat -f '%u' "${file}" 2>/dev/null || echo "unknown"
+  fi
+}
+
 # Validate file permissions - BLOCKING (returns 1 if insecure)
 check_file_permissions() {
   local file="$1"
   local perms
 
   # Get permissions (Darwin vs Linux stat syntax)
-  perms="$(stat -f '%A' "${file}" 2>/dev/null || stat -c '%a' "${file}" 2>/dev/null || echo "unknown")"
+  perms="$(_stat_perms "${file}")"
 
   if [[ "${perms}" == "unknown" ]]; then
     log_error "Could not check permissions for ${file}"
@@ -31,7 +57,7 @@ check_file_permissions() {
   # Verify file is owned by current user
   local file_owner
   local current_uid
-  file_owner="$(stat -f '%u' "${file}" 2>/dev/null || stat -c '%u' "${file}" 2>/dev/null || echo "unknown")"
+  file_owner="$(_stat_owner_uid "${file}")"
   current_uid="$(id -u)" || current_uid="unknown"
   if [[ "${file_owner}" != "${current_uid}" ]]; then
     log_error "${file} is not owned by current user (owner: ${file_owner}, current: ${current_uid})"
@@ -51,7 +77,7 @@ ensure_secure_permissions() {
   local perms
 
   # Get permissions (Darwin vs Linux stat syntax)
-  perms="$(stat -f '%A' "${file}" 2>/dev/null || stat -c '%a' "${file}" 2>/dev/null || echo "unknown")"
+  perms="$(_stat_perms "${file}")"
 
   if [[ "${perms}" == "unknown" ]]; then
     log_error "Could not check permissions for ${file}"
@@ -61,7 +87,7 @@ ensure_secure_permissions() {
   # Verify file is owned by current user first
   local file_owner
   local current_uid
-  file_owner="$(stat -f '%u' "${file}" 2>/dev/null || stat -c '%u' "${file}" 2>/dev/null || echo "unknown")"
+  file_owner="$(_stat_owner_uid "${file}")"
   current_uid="$(id -u)" || current_uid="unknown"
   if [[ "${file_owner}" != "${current_uid}" ]]; then
     log_error "${file} is not owned by current user (owner: ${file_owner}, current: ${current_uid})"


### PR DESCRIPTION
## Summary
- `stat -f ... || stat -c ...` fallback chaining is unreliable for BSD/GNU stat detection: GNU coreutils' `-f` flag means "filesystem status" (not a format-string flag), so on Linux it prints multi-line filesystem info to stdout and can still exit 0 — the fallback to `stat -c` never triggers, and that garbage gets parsed as permission bits / owner UID.
- Confirmed as the root cause of the currently-failing `shell-tests` CI check (`check_file_permissions accepts 600 permissions`) on `main`, reproduced identically on PRs #83 and #84 (neither of which touches this file).
- Adds `_stat_perms()` / `_stat_owner_uid()` helpers that probe `stat --version` once (GNU-only flag, reliably distinguishes GNU vs BSD stat) to pick the correct invocation deterministically, replacing all 4 occurrences of the old fallback pattern in `lib/permissions.sh`.
- Scoped to this file only, per the diagnosis — does not touch `lib/binary-discovery.sh` or `tests/test-wrapper.sh`, which have the same pattern; pre-push review filed non-blocking tracking issues #85, #86, #87 for those.

## Test plan
- [x] `bash tests/test-wrapper.sh` — 61/61 pass, including `check_file_permissions accepts 600 permissions` (Section 3.2) and `ensure_secure_permissions fixes to target permissions` (Section 3.3)
- [x] `shellcheck --external-sources lib/permissions.sh` — clean
- [x] Local pre-commit review (code-reviewer + adversarial-reviewer) — both PASS
- [x] Pre-push full-diff + codebase review — PASS
- [ ] CI `shell-tests` check on Linux — confirms the actual bug path; will report once green

https://claude.ai/code/session_01BmuTHyHEJv26WZkyTWHZDp