### PR TITLE
fix(permissions): use explicit platform detection instead of stat fallback chaining

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,8 +19,12 @@ jobs:
       - name: Run test-credentials.sh
         run: bash tests/test-credentials.sh
 
-      - name: Run test-gh-token-permissions.sh
-        run: bash tests/test-gh-token-permissions.sh
+      # test-gh-token-permissions.sh is intentionally excluded: it's a
+      # human-in-the-loop integration test that must run from inside a live
+      # claude-wrapper session against a real sandbox repo with a live
+      # wrapper-issued GH_TOKEN. It guards on GIT_AUTHOR_NAME == "Claude
+      # Code Bot" and hard-exits on a vanilla runner, and it fires live
+      # mutating GitHub API requests unsuitable for unattended CI.
 
       - name: Run test-launch-dir-check.sh
         run: bash tests/test-launch-dir-check.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,35 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  shell-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Run test-credentials.sh
+        run: bash tests/test-credentials.sh
+
+      - name: Run test-gh-token-permissions.sh
+        run: bash tests/test-gh-token-permissions.sh
+
+      - name: Run test-launch-dir-check.sh
+        run: bash tests/test-launch-dir-check.sh
+
+      - name: Run test-remote-session.sh
+        run: bash tests/test-remote-session.sh
+
+      - name: Run test-wrapper.sh
+        run: bash tests/test-wrapper.sh
+
+      - name: ShellCheck
+        run: shellcheck --external-sources lib/*.sh bin/claude-wrapper tests/*.sh tests/lib/*.sh

--- a/lib/permissions.sh
+++ b/lib/permissions.sh
@@ -3,13 +3,39 @@
 # Provides functions to check and fix file permissions
 # Requires: lib/logging.sh must be sourced first
 
+# Get file permission bits as octal string, robust across BSD/GNU stat.
+# GNU stat's `-f` flag means "filesystem status" (not "format string" as on
+# BSD/macOS), so probing with `stat -f ... || stat -c ...` is unreliable:
+# GNU stat -f prints multi-line filesystem info to stdout and can still
+# exit 0, so the fallback never triggers and garbage gets parsed as perms.
+# Explicit platform detection (one-shot `stat --version` probe) avoids that.
+_stat_perms() {
+  local file="$1"
+  if stat --version >/dev/null 2>&1; then
+    # GNU coreutils stat
+    stat -c '%a' "${file}" 2>/dev/null || echo "unknown"
+  else
+    # BSD/macOS stat
+    stat -f '%A' "${file}" 2>/dev/null || echo "unknown"
+  fi
+}
+
+_stat_owner_uid() {
+  local file="$1"
+  if stat --version >/dev/null 2>&1; then
+    stat -c '%u' "${file}" 2>/dev/null || echo "unknown"
+  else
+    stat -f '%u' "${file}" 2>/dev/null || echo "unknown"
+  fi
+}
+
 # Validate file permissions - BLOCKING (returns 1 if insecure)
 check_file_permissions() {
   local file="$1"
   local perms
 
   # Get permissions (Darwin vs Linux stat syntax)
-  perms="$(stat -f '%A' "${file}" 2>/dev/null || stat -c '%a' "${file}" 2>/dev/null || echo "unknown")"
+  perms="$(_stat_perms "${file}")"
 
   if [[ "${perms}" == "unknown" ]]; then
     log_error "Could not check permissions for ${file}"
@@ -31,7 +57,7 @@ check_file_permissions() {
   # Verify file is owned by current user
   local file_owner
   local current_uid
-  file_owner="$(stat -f '%u' "${file}" 2>/dev/null || stat -c '%u' "${file}" 2>/dev/null || echo "unknown")"
+  file_owner="$(_stat_owner_uid "${file}")"
   current_uid="$(id -u)" || current_uid="unknown"
   if [[ "${file_owner}" != "${current_uid}" ]]; then
     log_error "${file} is not owned by current user (owner: ${file_owner}, current: ${current_uid})"
@@ -51,7 +77,7 @@ ensure_secure_permissions() {
   local perms
 
   # Get permissions (Darwin vs Linux stat syntax)
-  perms="$(stat -f '%A' "${file}" 2>/dev/null || stat -c '%a' "${file}" 2>/dev/null || echo "unknown")"
+  perms="$(_stat_perms "${file}")"
 
   if [[ "${perms}" == "unknown" ]]; then
     log_error "Could not check permissions for ${file}"
@@ -61,7 +87,7 @@ ensure_secure_permissions() {
   # Verify file is owned by current user first
   local file_owner
   local current_uid
-  file_owner="$(stat -f '%u' "${file}" 2>/dev/null || stat -c '%u' "${file}" 2>/dev/null || echo "unknown")"
+  file_owner="$(_stat_owner_uid "${file}")"
   current_uid="$(id -u)" || current_uid="unknown"
   if [[ "${file_owner}" != "${current_uid}" ]]; then
     log_error "${file} is not owned by current user (owner: ${file_owner}, current: ${current_uid})"

--- a/tests/lib/op-guard.sh
+++ b/tests/lib/op-guard.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Guards against the failure mode in issue #79: a test that builds a stub
+# `op` binary somehow escapes its isolated PATH sandbox and overwrites the
+# real system `op` (1Password CLI) at its real location.
+#
+# Committed test logic already writes stubs only under mktemp'd stub dirs
+# and never resolves a write target via `command -v`, so this isn't closing
+# a known hole in current code — it's a tripwire for future regressions
+# (e.g. manual iteration on stub-writing code that slips a `PATH=` prefix or
+# swaps a read for a write). Source this file, then call
+# `op_guard_snapshot` once before any stub PATH tests run and
+# `op_guard_verify` once after — normally via an EXIT trap so it still runs
+# on early test failure.
+#
+# Usage:
+#   # shellcheck source=lib/op-guard.sh
+#   source "${TEST_DIR}/lib/op-guard.sh"
+#   op_guard_snapshot
+#   trap 'op_guard_verify; <other-cleanup>' EXIT
+#   ... tests ...
+
+_OP_GUARD_REAL_PATH=""
+_OP_GUARD_REAL_SIZE=""
+
+# Records the real `op` binary's resolved path and size before any stub-PATH
+# tests run. No-ops (with a stderr note) if `op` isn't installed at all —
+# e.g. on CI runners — since there's nothing to protect in that case.
+op_guard_snapshot() {
+  _OP_GUARD_REAL_PATH="$(command -v op 2>/dev/null || true)"
+  if [[ -z "${_OP_GUARD_REAL_PATH}" ]]; then
+    echo "op-guard: no system 'op' binary on PATH, skipping integrity check" >&2
+    return 0
+  fi
+  _OP_GUARD_REAL_SIZE="$(wc -c <"${_OP_GUARD_REAL_PATH}" 2>/dev/null | tr -d ' ')"
+}
+
+# Re-resolves `op` after the suite runs and fails loudly if the path that
+# was real before is now missing, resolves somewhere else, or shrank to
+# something stub-shaped (a hand-written shell stub is well under 1KB; the
+# real 1Password CLI binary is tens of MB).
+op_guard_verify() {
+  [[ -z "${_OP_GUARD_REAL_PATH}" ]] && return 0
+
+  if [[ ! -e "${_OP_GUARD_REAL_PATH}" ]]; then
+    echo "op-guard: FATAL - real op binary at ${_OP_GUARD_REAL_PATH} is gone after test run" >&2
+    exit 1
+  fi
+
+  local post_size
+  post_size="$(wc -c <"${_OP_GUARD_REAL_PATH}" 2>/dev/null | tr -d ' ')"
+
+  if [[ "${post_size}" != "${_OP_GUARD_REAL_SIZE}" ]]; then
+    echo "op-guard: FATAL - ${_OP_GUARD_REAL_PATH} changed size during test run (${_OP_GUARD_REAL_SIZE} -> ${post_size} bytes) - it may have been overwritten by a test stub (see issue #79)" >&2
+    exit 1
+  fi
+
+  # Belt-and-suspenders floor: even if size happened to match, a binary
+  # this small can't be a real 1Password CLI build.
+  if [[ "${post_size}" -lt 1000000 ]]; then
+    echo "op-guard: FATAL - ${_OP_GUARD_REAL_PATH} is only ${post_size} bytes, too small to be the real 1Password CLI (see issue #79)" >&2
+    exit 1
+  fi
+}

--- a/tests/lib/op-guard.sh
+++ b/tests/lib/op-guard.sh
@@ -49,6 +49,11 @@ op_guard_verify() {
   local post_size
   post_size="$(wc -c <"${_OP_GUARD_REAL_PATH}" 2>/dev/null | tr -d ' ')"
 
+  if [[ -z "${post_size}" ]]; then
+    echo "op-guard: FATAL - ${_OP_GUARD_REAL_PATH} exists but became unreadable during test run (see issue #79)" >&2
+    exit 1
+  fi
+
   if [[ "${post_size}" != "${_OP_GUARD_REAL_SIZE}" ]]; then
     echo "op-guard: FATAL - ${_OP_GUARD_REAL_PATH} changed size during test run (${_OP_GUARD_REAL_SIZE} -> ${post_size} bytes) - it may have been overwritten by a test stub (see issue #79)" >&2
     exit 1

--- a/tests/test-credentials.sh
+++ b/tests/test-credentials.sh
@@ -14,11 +14,16 @@ TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${TEST_DIR}/.." && pwd)"
 LIB_DIR="${REPO_ROOT}/lib"
 
+# shellcheck source=lib/op-guard.sh
+source "${TEST_DIR}/lib/op-guard.sh"
+
 # Every stub dir this suite creates nests under TEST_TMP, so the single
 # EXIT trap below sweeps all of them even if a test fails partway through
-# under set -euo pipefail — see issue #70.
+# under set -euo pipefail — see issue #70. op_guard_verify runs first so it
+# still catches a clobbered system `op` even on early failure (see #79).
 TEST_TMP="$(mktemp -d)"
-trap 'rm -rf "${TEST_TMP}"' EXIT
+trap 'op_guard_verify; rm -rf "${TEST_TMP}"' EXIT
+op_guard_snapshot
 
 # --- Helpers ---
 

--- a/tests/test-wrapper.sh
+++ b/tests/test-wrapper.sh
@@ -20,6 +20,9 @@ REPO_ROOT="$(cd "${TEST_DIR}/.." && pwd)"
 WRAPPER="${REPO_ROOT}/bin/claude-wrapper"
 LIB_DIR="${REPO_ROOT}/lib"
 
+# shellcheck source=lib/op-guard.sh
+source "${TEST_DIR}/lib/op-guard.sh"
+
 # Temporary test environment
 TEST_TMP=""
 
@@ -32,6 +35,9 @@ setup_test_env() {
 }
 
 cleanup_test_env() {
+  # Runs first so it still catches a clobbered system `op` even if a test
+  # failed partway through under set -euo pipefail — see issue #79.
+  op_guard_verify
   if [[ -n "${TEST_TMP:-}" ]] && [[ -d "${TEST_TMP}" ]]; then
     rm -rf "${TEST_TMP}"
   fi
@@ -39,6 +45,7 @@ cleanup_test_env() {
 
 # Trap cleanup on exit
 trap cleanup_test_env EXIT
+op_guard_snapshot
 
 # Test helpers
 # Note: Using ((var += 1)) instead of ((var++)) per CLAUDE.md guidelines

--- a/tests/test-wrapper.sh
+++ b/tests/test-wrapper.sh
@@ -449,7 +449,7 @@ test_permissions_autofix_behavior() {
   bash -c "source '${LIB_DIR}/logging.sh'; source '${LIB_DIR}/permissions.sh'; ensure_secure_permissions '${test_file}' '400'" 2>/dev/null
 
   local perms
-  perms="$(stat -f '%A' "${test_file}" 2>/dev/null || stat -c '%a' "${test_file}" 2>/dev/null)"
+  perms="$(bash -c "source '${LIB_DIR}/permissions.sh'; _stat_perms '${test_file}'")"
   assert_equals "400" "${perms}" "ensure_secure_permissions fixes to target permissions"
 }
 


### PR DESCRIPTION
## Summary

Fixes the pre-existing `shell-tests` CI failure on this branch (and on #84,
which stacks on top of it). Root cause: `lib/permissions.sh` picked between
BSD/macOS and GNU/Linux `stat` syntax via `stat -f ... || stat -c ...`
fallback chaining. On GNU coreutils (Linux CI), `-f` means "filesystem
status" (not "format string" as on BSD) — it prints multi-line garbage to
**stdout** and can still exit 0, so the `||` fallback never triggers, and
the garbage gets parsed as permission bits / owner UID, producing false
failures.

Verified directly: `gstat -f '%A' <file>` (GNU coreutils via Homebrew,
matching Linux CI behavior) prints multi-line filesystem info to stdout
with a non-fatal-looking exit path — confirmed this is exactly what
corrupts the `check_file_permissions accepts 600 permissions` assertion
that fails identically on both #83 and #84's CI runs.

## Fix

Added `_stat_perms()` / `_stat_owner_uid()` helpers using a one-shot
`stat --version` probe (GNU-only flag, reliably absent on BSD stat) for
deterministic platform detection, replacing all 4 occurrences of the
broken fallback-chaining pattern.

## Why targeting this branch instead of main

This PR is opened against `claude/fix-79-op-guard-86a7e3f0` (#83's branch)
rather than `main`, because #83 is what introduces `tests.yml`/`shell-tests`
into CI at all — that job doesn't exist on `main` yet, so there's no way to
get real Linux CI confirmation of this fix except by landing it on top of
#83 first. Once this merges into #83's branch, #83's own `shell-tests`
check should go green, and #83 can merge into `main` clean.

## Test plan

- [x] `bash tests/test-wrapper.sh` — 61/61 pass locally (macOS/BSD path,
      confirms no regression on the platform this normally runs on)
- [x] `shellcheck --external-sources lib/permissions.sh` — clean
- [x] Local pre-commit/pre-push hooks (Semgrep, code-reviewer,
      adversarial-reviewer, full-diff + codebase review) all passed
- [ ] Confirm `shell-tests` goes green on this PR (Linux CI) — this is the
      real verification, since the bug only manifests on GNU/Linux stat