### PR TITLE
fix(lint): resolve pre-existing shellcheck info-level findings on main

### DIFF
--- a/bin/claude-wrapper
+++ b/bin/claude-wrapper
@@ -10,34 +10,34 @@ WRAPPER_DIR="$(dirname "${WRAPPER_PATH}")"
 WRAPPER_LIB="${WRAPPER_DIR}/../lib"
 
 # Source all modules in dependency order
-# shellcheck source=../lib/logging.sh
+# shellcheck source=lib/logging.sh
 source "${WRAPPER_LIB}/logging.sh"
 
-# shellcheck source=../lib/permissions.sh
+# shellcheck source=lib/permissions.sh
 source "${WRAPPER_LIB}/permissions.sh"
 
-# shellcheck source=../lib/path-security.sh
+# shellcheck source=lib/path-security.sh
 source "${WRAPPER_LIB}/path-security.sh"
 
-# shellcheck source=../lib/launch-dir-check.sh
+# shellcheck source=lib/launch-dir-check.sh
 source "${WRAPPER_LIB}/launch-dir-check.sh"
 
-# shellcheck source=../lib/git-identity.sh
+# shellcheck source=lib/git-identity.sh
 source "${WRAPPER_LIB}/git-identity.sh"
 
-# shellcheck source=../lib/credentials.sh
+# shellcheck source=lib/credentials.sh
 source "${WRAPPER_LIB}/credentials.sh"
 
-# shellcheck source=../lib/secrets-loader.sh
+# shellcheck source=lib/secrets-loader.sh
 source "${WRAPPER_LIB}/secrets-loader.sh"
 
-# shellcheck source=../lib/binary-discovery.sh
+# shellcheck source=lib/binary-discovery.sh
 source "${WRAPPER_LIB}/binary-discovery.sh"
 
-# shellcheck source=../lib/pre-launch.sh
+# shellcheck source=lib/pre-launch.sh
 source "${WRAPPER_LIB}/pre-launch.sh"
 
-# shellcheck source=../lib/remote-session.sh
+# shellcheck source=lib/remote-session.sh
 source "${WRAPPER_LIB}/remote-session.sh"
 
 # Warn (non-blocking) if launched from $HOME or $HOME/Developer exactly

--- a/tests/test-credentials.sh
+++ b/tests/test-credentials.sh
@@ -181,6 +181,7 @@ result="$(
 )"
 assert_equals "vault-gh-token" "${result}" \
   "op read succeeds -> GH_TOKEN exported from vault"
+# shellcheck disable=SC2312  # exit status of wc/tr intentionally discarded; this assertion checks captured output, not command success
 assert_equals "1" "$(wc -l <"${call_log}" | tr -d ' ')" \
   "op read succeeds on first attempt -> called exactly once"
 

--- a/tests/test-launch-dir-check.sh
+++ b/tests/test-launch-dir-check.sh
@@ -19,7 +19,7 @@ debug_log() { :; }
 log_warn() { echo "WARNING: $*" >&2; }
 
 # Source the module under test
-# shellcheck source=../lib/launch-dir-check.sh
+# shellcheck source=lib/launch-dir-check.sh
 source "${LIB_DIR}/launch-dir-check.sh"
 
 # --- Helpers ---

--- a/tests/test-remote-session.sh
+++ b/tests/test-remote-session.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Test suite for lib/remote-session.sh
+# shellcheck disable=SC2312  # command substitutions inside assert_* calls capture output by design; exit status is not the thing under test
 set -euo pipefail
 
 RED='\033[0;31m'
@@ -18,7 +19,7 @@ LIB_DIR="${REPO_ROOT}/lib"
 debug_log() { :; }
 
 # Source the module under test
-# shellcheck source=../lib/remote-session.sh
+# shellcheck source=lib/remote-session.sh
 source "${LIB_DIR}/remote-session.sh"
 
 # --- Helpers ---

--- a/tests/test-wrapper.sh
+++ b/tests/test-wrapper.sh
@@ -63,6 +63,7 @@ assert_equals() {
   return 0
 }
 
+# shellcheck disable=SC2329  # part of the shared assertion helper set; no current caller needs "not equals" but kept for future test authors alongside assert_equals/assert_contains
 assert_not_equals() {
   local unexpected="$1"
   local actual="$2"


### PR DESCRIPTION
## Summary

- CI's new `shell-tests` job (introduced by #83, still unmerged) runs `shellcheck --external-sources lib/*.sh bin/claude-wrapper tests/*.sh tests/lib/*.sh` as its last step — the first time shellcheck has ever run in CI for this repo.
- shellcheck's default severity floor is `style` (most inclusive), so any info-level finding fails the job.
- Running the command against plain `main` today surfaces ~30 pre-existing info-level findings unrelated to #83's own changes, which transitively blocks #83, #84, and #90 from ever showing a clean CI run.
- This PR fixes every finding on `main` directly (independent of #83/#84/#90), verified via `shellcheck --external-sources lib/*.sh bin/claude-wrapper tests/*.sh` (the `tests/lib/*.sh` glob isn't on `main` yet — it only exists on #83's branch).

## Findings and fixes

- **SC1091 (info, 11x)** — "Not following" errors for `source "${WRAPPER_LIB}/...sh"` / `source "${LIB_DIR}/...sh"` lines in `bin/claude-wrapper`, `tests/test-launch-dir-check.sh`, `tests/test-remote-session.sh`. Root cause: shellcheck resolves `# shellcheck source=` directive paths **relative to its invocation CWD** (repo root, matching CI), not relative to the file being checked — verified empirically in an isolated sandbox before applying. Existing directives used `../lib/*.sh`, which only resolves when shellcheck is invoked from inside `bin/` or `tests/`. Fixed by changing directives to root-relative `lib/*.sh` paths. Real fix, not a suppression.
- **SC2312 (info, ~20x)** — "Consider invoking this command separately..." inside `assert_true "$(...)"` / `assert_equals "..." "$(...)"` test-assertion patterns in `tests/test-credentials.sh` and `tests/test-remote-session.sh`. The command substitution intentionally captures output for the assertion; exit status isn't the thing under test. Fixed with scoped `# shellcheck disable=SC2312` comments — inline for the single occurrence in `test-credentials.sh`, file-level for the dense block (~20 occurrences) in `test-remote-session.sh` — each with a one-line rationale, matching the existing convention already used in `tests/test-gh-token-permissions.sh`.
- **SC2329 (info, 1x)** — `assert_not_equals()` in `tests/test-wrapper.sh` has no call sites anywhere in current or historical code, but is a natural companion to `assert_equals` in the shared test-assertion helper set. Kept (not removed) with a scoped disable comment noting it's available for future test authors, rather than deleting test infrastructure.

## Out of scope (explicitly not touched)

- `.github/workflows/tests.yml`
- `lib/permissions.sh` / the `stat -f`/`-c` platform-detection fix (separate concern on #90)
- PR #83, #84, #90 branches — this PR targets `main` directly

## Test plan

- [x] `shellcheck --external-sources lib/*.sh bin/claude-wrapper tests/*.sh` exits 0 with zero findings
- [x] `bash tests/test-wrapper.sh` — 50/50 passed (unchanged from baseline)
- [x] `bash tests/test-credentials.sh` — 11/11 passed (unchanged)
- [x] `bash tests/test-launch-dir-check.sh` — 6/6 passed (unchanged)
- [x] `bash tests/test-remote-session.sh` — 26/26 passed (unchanged)
- [x] Local pre-commit review (code-reviewer + adversarial-reviewer): PASS
- [x] Local pre-push review (full-diff + codebase review): PASS

https://claude.ai/code/session_01BmuTHyHEJv26WZkyTWHZDp