### PR TITLE
fix(permissions): cache stat-flavor detection at source time (#91, #87)

### DIFF
--- a/lib/permissions.sh
+++ b/lib/permissions.sh
@@ -9,9 +9,18 @@
 # GNU stat -f prints multi-line filesystem info to stdout and can still
 # exit 0, so the fallback never triggers and garbage gets parsed as perms.
 # Explicit platform detection (one-shot `stat --version` probe) avoids that.
+#
+# The platform never changes during a process lifetime, so detect it once
+# at source time and cache the result, rather than re-probing on every call.
+if stat --version >/dev/null 2>&1; then
+  _STAT_IS_GNU=true
+else
+  _STAT_IS_GNU=false
+fi
+
 _stat_perms() {
   local file="$1"
-  if stat --version >/dev/null 2>&1; then
+  if [[ "${_STAT_IS_GNU}" == "true" ]]; then
     # GNU coreutils stat
     stat -c '%a' "${file}" 2>/dev/null || echo "unknown"
   else
@@ -22,7 +31,7 @@ _stat_perms() {
 
 _stat_owner_uid() {
   local file="$1"
-  if stat --version >/dev/null 2>&1; then
+  if [[ "${_STAT_IS_GNU}" == "true" ]]; then
     stat -c '%u' "${file}" 2>/dev/null || echo "unknown"
   else
     stat -f '%u' "${file}" 2>/dev/null || echo "unknown"


### PR DESCRIPTION
## Summary
- `_stat_perms()` and `_stat_owner_uid()` in `lib/permissions.sh` each independently ran `stat --version >/dev/null 2>&1` on every call to detect GNU vs BSD stat, forking a subprocess even though the platform never changes during a process lifetime.
- `check_file_permissions` and `ensure_secure_permissions` each call both helpers, so a single permissions check could spawn up to 4 unnecessary subshells — happening on every wrapper invocation since permission checks run at startup.
- Fix: detect the platform once at source time into a cached `_STAT_IS_GNU` variable, and branch on that cached value in both helpers instead of re-probing each call. Behavior (output format, fallback to "unknown" on stat failure) is unchanged.

Closes #91, Closes #87

## Test plan
- [x] `shellcheck --external-sources lib/permissions.sh -S info` — clean
- [x] `bash tests/test-wrapper.sh` — 61/61 passed
- [x] `bash tests/test-remote-session.sh` — 26/26 passed
- [x] `bash tests/test-gh-token-permissions.sh` — one pre-existing failure ("Cannot read repo metadata") verified present on `main` too, unrelated to this change (live network/token test flagged as unreliable in project memory)

https://claude.ai/code/session_01JvRKqiuB6YMyhdGmBCU1P7