### PR TITLE
fix(tests): correct op-guard.sh floor check and doc ordering

### DIFF
--- a/tests/lib/op-guard.sh
+++ b/tests/lib/op-guard.sh
@@ -15,9 +15,12 @@
 # Usage:
 #   # shellcheck source=lib/op-guard.sh
 #   source "${TEST_DIR}/lib/op-guard.sh"
-#   op_guard_snapshot
 #   trap 'op_guard_verify; <other-cleanup>' EXIT
+#   op_guard_snapshot
 #   ... tests ...
+#
+# Trap-first is safe: op_guard_verify no-ops while _OP_GUARD_REAL_PATH is
+# still empty, i.e. before op_guard_snapshot has run.
 
 _OP_GUARD_REAL_PATH=""
 _OP_GUARD_REAL_SIZE=""
@@ -64,13 +67,13 @@ op_guard_verify() {
 
   if [[ "${post_size}" != "${_OP_GUARD_REAL_SIZE}" ]]; then
     echo "op-guard: FATAL - ${_OP_GUARD_REAL_PATH} changed size during test run (${_OP_GUARD_REAL_SIZE} -> ${post_size} bytes) - it may have been overwritten by a test stub (see issue #79)" >&2
-    exit 1
-  fi
-
-  # Belt-and-suspenders floor: even if size happened to match, a binary
-  # this small can't be a real 1Password CLI build.
-  if [[ "${post_size}" -lt 1000000 ]]; then
-    echo "op-guard: FATAL - ${_OP_GUARD_REAL_PATH} is only ${post_size} bytes, too small to be the real 1Password CLI (see issue #79)" >&2
+    # Belt-and-suspenders floor: a shrink onto something this small can't be
+    # a real 1Password CLI build. Only evaluated on the changed-size path
+    # (see issue #89) — a binary that never changed size, however small,
+    # was never touched by a test stub and isn't this check's concern.
+    if [[ "${post_size}" -lt 1000000 ]]; then
+      echo "op-guard: FATAL - ${_OP_GUARD_REAL_PATH} is only ${post_size} bytes, too small to be the real 1Password CLI (see issue #79)" >&2
+    fi
     exit 1
   fi
 }


### PR DESCRIPTION
## Summary

- **Issue #94**: The header usage example in `tests/lib/op-guard.sh` showed `op_guard_snapshot` called before `trap ... EXIT` was set, but both real callers (`tests/test-wrapper.sh` lines 47-48, `tests/test-credentials.sh` lines 25-26) actually do trap-first, then snapshot. Updated the doc to match reality, with a one-line note explaining why trap-first is safe: `op_guard_verify` no-ops while `_OP_GUARD_REAL_PATH` is still empty (i.e. before `op_guard_snapshot` has run).
- **Issue #89** (scoped down per the scoping comment already posted on that issue): the 1MB floor check in `op_guard_verify()` previously ran unconditionally after the size-equality check, but by that point in the function `post_size == _OP_GUARD_REAL_SIZE` is already guaranteed (the equality check above it exits early on any mismatch). That made the floor check dead code for the "did it change" case, and spuriously FATAL on dev machines where `op` resolves to a small binary that never changed (e.g. a package-manager proxy/version-switcher shim under 1MB) — every test run would fail even though nothing touched the binary.

## Fix

Nested the floor check inside the existing changed-size branch, so it only evaluates — as an additional diagnostic detail on the same `exit 1` path — when the binary's size actually differs from the pre-recorded real size. A binary that never changed size, however small, no longer triggers a false FATAL. The size-equality check's own `exit 1` behavior for a real size mismatch is unchanged.

## Test plan

- [x] `shellcheck --external-sources tests/lib/op-guard.sh` — clean
- [x] `bash tests/test-wrapper.sh` — 61/61 passed
- [x] `bash tests/test-credentials.sh` — 11/11 passed
- [x] `bash tests/test-gh-token-permissions.sh` — pre-existing failure in "Read repository metadata" confirmed unrelated: the sandbox repo `smartwatermelon/test-gh-token-permissions` returns 404 via `gh api` directly, independent of this change
- [x] `bash tests/test-remote-session.sh` — 26/26 passed
- [x] Local pre-commit review (code-reviewer + adversarial-reviewer) — PASS
- [x] Pre-push full-diff + codebase review — PASS

Closes #94, Closes #89

https://claude.ai/code/session_01JvRKqiuB6YMyhdGmBCU1P7