### PR TITLE
fix(binary-discovery): use shared stat helpers instead of broken fallback chain (#85)

### DIFF
--- a/lib/binary-discovery.sh
+++ b/lib/binary-discovery.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Claude binary discovery for claude-wrapper
 # Finds and validates the real claude binary
-# Requires: lib/logging.sh and lib/path-security.sh must be sourced first
+# Requires: lib/logging.sh, lib/permissions.sh, and lib/path-security.sh must be sourced first
+# (validate_claude_binary uses the _stat_perms/_stat_owner_uid helpers from permissions.sh)
 
 # Find the real claude binary, excluding the wrapper itself
 find_claude_binary() {
@@ -64,7 +65,7 @@ validate_claude_binary() {
 
   # Check owner (should be current user or root)
   local current_uid
-  binary_owner="$(stat -f '%u' "${binary}" 2>/dev/null || stat -c '%u' "${binary}" 2>/dev/null || echo "unknown")"
+  binary_owner="$(_stat_owner_uid "${binary}")"
   current_uid="$(id -u)" || current_uid="unknown"
   if [[ "${binary_owner}" != "${current_uid}" ]] && [[ "${binary_owner}" != "0" ]]; then
     log_error "Claude binary has unexpected owner (${binary_owner}): ${binary}"
@@ -72,7 +73,7 @@ validate_claude_binary() {
   fi
 
   # Check permissions (should not be world-writable)
-  binary_perms="$(stat -f '%A' "${binary}" 2>/dev/null || stat -c '%a' "${binary}" 2>/dev/null || echo "unknown")"
+  binary_perms="$(_stat_perms "${binary}")"
   if [[ "${binary_perms: -1}" =~ [2367] ]]; then
     log_error "Claude binary is world-writable (${binary_perms}): ${binary}"
     return 1


### PR DESCRIPTION
## Summary
- `lib/binary-discovery.sh` still used the old `stat -f ... || stat -c ...` fallback chain that PR #88 already fixed in `lib/permissions.sh`
- On Linux, GNU `stat -f` means "filesystem status" (not a BSD-style format flag), so it can print multi-line filesystem info and still exit 0 — the `|| stat -c ...` fallback never triggers, and garbage gets parsed as owner/permissions in `validate_claude_binary()`
- Replaced both broken `stat` invocations with calls to the existing `_stat_owner_uid()`/`_stat_perms()` helpers from `lib/permissions.sh`, which do explicit platform detection via a one-time `stat --version` probe
- `permissions.sh` is already sourced before `binary-discovery.sh` in `bin/claude-wrapper`, so both helpers are guaranteed available — no duplication of the platform-detection logic

Closes #85

## Test plan
- [x] `shellcheck --external-sources lib/binary-discovery.sh` — clean
- [x] `bash tests/test-wrapper.sh` — 61/61 passed
- [x] `bash tests/test-remote-session.sh` — 26/26 passed
- [x] `bash tests/test-gh-token-permissions.sh` — pre-existing, unrelated failure on a live `gh api` sandbox-repo check (confirmed reproduces identically on `main`, unaffected by this change)
- [x] Automated pre-commit and pre-push local review agents (code-reviewer, adversarial-reviewer, full-diff, codebase review) all passed

https://claude.ai/code/session_01JvRKqiuB6YMyhdGmBCU1P7