### PR TITLE
fix(binary-discovery): correct stale path-security.sh dependency claim

### DIFF
--- a/lib/binary-discovery.sh
+++ b/lib/binary-discovery.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Claude binary discovery for claude-wrapper
 # Finds and validates the real claude binary
-# Requires: lib/logging.sh, lib/permissions.sh, and lib/path-security.sh must be sourced first
+# Requires: lib/logging.sh and lib/permissions.sh must be sourced first
 # (validate_claude_binary uses the _stat_perms/_stat_owner_uid helpers from permissions.sh)
 
 # Find the real claude binary, excluding the wrapper itself


### PR DESCRIPTION
## Summary
- Fixes #103: `lib/binary-discovery.sh` header claimed `lib/path-security.sh` must be sourced first, but `validate_claude_binary` never calls `canonicalize_path` — it only uses `_stat_perms`/`_stat_owner_uid` from `permissions.sh` and `realpath` directly.
- Documentation-only comment fix; no functional change.

## Test plan
- [x] `shellcheck --external-sources lib/binary-discovery.sh` clean
- [x] `bash tests/test-wrapper.sh` — 64/64 pass
- [x] Local code-reviewer + adversarial-reviewer: PASS
- [x] Pre-push full-diff + codebase review: PASS

https://claude.ai/code/session_01P4g5jBJkkX8BoV9rt1VmGG
