### PR TITLE
fix(ci): repoint assistant workflow from stale SHA to @v3.1.2

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,6 +20,6 @@ jobs:
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association))
-    uses: smartwatermelon/github-workflows/.github/workflows/claude-assistant.yml@9615f932744f8cb372e4650c73d52559219efdf1 # v3
+    uses: smartwatermelon/github-workflows/.github/workflows/claude-assistant.yml@v3.1.2
     secrets:
       claude_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## The exposure

`.github/workflows/claude.yml` pinned the shared assistant reusable workflow to a **raw commit SHA** rather than a semver tag:

```
smartwatermelon/github-workflows/.github/workflows/claude-assistant.yml@9615f932744f8cb372e4650c73d52559219efdf1
```

`9615f93` is from 2026-08-07. Because it's a SHA and not a floating tag, the fleet-wide tag repoint that patched every other consumer repo never reached this one. This repo stayed on the old code.

That commit's `claude-assistant.yml` carries `anthropics/claude-code-action@26ec0412` — **v1.0.70, vulnerable to GHSA-8q5r-mmjf-575q** (patched upstream in 1.0.74).

Verified against the contents API at both refs before changing anything:

| ref | `claude-code-action` pin |
|---|---|
| `@9615f93` | `26ec0412` &nbsp;# v1 (1.0.70 — vulnerable) |
| `@v3.1.2` | `9d7150bc` &nbsp;# v1.0.193 (patched) |

## The fix

Repoint to `@v3.1.2`. Tags in `github-workflows` are repo-wide, and the whole fleet tracks the `v3` line (10 repos on `@v3`, 2 on `@v3.0.0`, 1 each on `@v3.1.0`/`@v3.1.1`); no consumer is on `v1`. `v3.1.2` is the current release.

Besides the advisory fix, v3.1.2 brings:

- `persist-credentials: false` on checkout
- the template-injection fix
- `actions/checkout` v7.0.1
- a fail-fast precondition check when `CLAUDE_CODE_OAUTH_TOKEN` is missing

## Interface compatibility

Diffed the reusable workflow between the two refs. Every change is inside the job's `steps:` — the `workflow_call` interface is untouched:

- **Inputs:** none declared at either ref.
- **Secrets:** one, `claude_oauth_token` (`required: false`), unchanged. This caller already passes it.
- **Permissions:** v3.1.2 needs `contents: read`, `pull-requests: read`, `issues: read`, `id-token: write`. All four are already declared at the top of this caller. No change needed.

Nothing was added that the caller must supply, and nothing it supplies was removed. Ref change only — one line.

## Notes

- Committed with `SKIP=zizmor`. The sole finding is `unpinned-uses` on the tag ref, which is deliberate fleet policy for first-party reusable workflows (documented at `README.md:207` in github-workflows). Pinning by SHA is the bug being fixed here.
- `claude-review / run-review` is expected to skip with `workflow-self-modification`, since this PR touches `.github/workflows/`.