### PR TITLE
fix(ci): float claude-assistant caller to @v3 for fleet-wide consistency

### DIFF
--- a/.github/workflows/claude-blocking-review.yml
+++ b/.github/workflows/claude-blocking-review.yml
@@ -12,7 +12,10 @@ permissions:
 
 jobs:
   claude-review:
-    uses: smartwatermelon/github-workflows/.github/workflows/claude-blocking-review.yml@v3
+    # Deliberate: float the first-party major tag to receive upstream security
+    # fixes without a PR here. Standardized fleet-wide; see #117.
+    # Same-owner reusable workflow, not a third-party action.
+    uses: smartwatermelon/github-workflows/.github/workflows/claude-blocking-review.yml@v3  # zizmor: ignore[unpinned-uses]
     with:
       pr_number: ${{ github.event.pull_request.number }}
     secrets:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,6 +20,9 @@ jobs:
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association))
-    uses: smartwatermelon/github-workflows/.github/workflows/claude-assistant.yml@v3.1.2
+    # Deliberate: float the first-party major tag to receive upstream security
+    # fixes without a PR here. Standardized fleet-wide; see #117.
+    # Same-owner reusable workflow, not a third-party action.
+    uses: smartwatermelon/github-workflows/.github/workflows/claude-assistant.yml@v3  # zizmor: ignore[unpinned-uses]
     secrets:
       claude_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
Closes #117

## What

Floats `.github/workflows/claude.yml` from the exact patch tag `@v3.1.2` to the major tag `@v3`, matching the convention PR #116 established for the blocking-review caller.

## Why the gap is real, not theoretical

Upstream `@v3` now resolves to `e51e6b1` (== `v3.2.0`), while `@v3.1.2` dereferences to `fefbd3d` — **eight commits behind**, including a +198/-2 change to `claude-assistant.yml` itself:

| Commit | Change |
| ------ | ------ |
| `3d6c409` | `fix(scripts)`: guard `rm -rf`, stop bypassing hooks |
| `7100b28` | `feat(zizmor)`: ship a config so consumers stop bypassing the linter |
| `382856e` | `feat(claude-assistant)`: add `allowed_tools` and `model` inputs |
| `4127f03` | `feat(claude-assistant)`: add `disallowed_tools` |

`disallowed_tools` is the only input that can genuinely **revoke** a tool the action grants itself (`allowed_tools` is additive — it unions with tag-mode's own allowlist). So the pin was withholding a security-relevant capability.

## Why this is safe as a bare ref change

All three new `workflow_call` inputs are `required: false` with `default: ''`, documented upstream as reproducing the action's own defaults exactly. This caller passes no `with:` block at all — only the `claude_oauth_token` secret. No caller-side adjustment needed.

## The tradeoff, stated plainly

Floating a mutable major tag means upstream can change what runs here without a PR in this repo, in exchange for automatic security-fix delivery. This is a **deliberate, directed standardization** — it's the convention #116 already adopted and that upstream's README recommends. Neither caller is reproducible-by-SHA anymore; that is the accepted cost.

## zizmor suppression

Adds a scoped `# zizmor: ignore[unpinned-uses]` to **both** callers, with rationale inline.

Worth noting: the blocking-review caller already on `main` fails this same audit *today* — #116 only got through because the pre-commit hook lints staged files only. Suppressing both states the policy once and removes a latent trap for whoever next edits that file. The suppression is scoped to a single audit on a single line, following the existing precedent at `dependabot-auto-merge.yml:3`.

## Verification

- `zizmor` on both files: **No findings to report** (was 2 high)
- `yamllint`: passes (only pre-existing long-line warnings on the untouched `if:` block)
- `tests/test-wrapper.sh`: 64/64 pass
- `tests/test-remote-session.sh`: 26/26 pass
- `tests/test-gh-token-permissions.sh`: fails **pre-existing** — reproduces identically with this change stashed; live-network token-scope test, unrelated to workflow YAML
- Local `code-reviewer` + `adversarial-reviewer`: both PASS

https://claude.ai/code/session_01TfyQqgNbWYZe3Hic4Ep6bi